### PR TITLE
0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,36 @@
 
 ## 0.8.1
 
+- big bugfix release
 - sheep
   - limit pru-warning count
   - fix forced stopping of ntp-service
   - improve debug-output
+  - fix ingestion of ivcurves (windowsize was not propagated)
+  - fix copy of emu-input into shared mem (off-by-one-error)
 - herd
   - query for alive status of testbed (all hosts responding)
   - more robust unittesting
+  - add automated benchmark in `software\shepherd-herd\test_manual\`
 - python in general
   - add progress-bars to long processes
   - remove progress-bar after task finishes (most)
   - don't limit pandas to <v2 anymore
+  - prepare for py313
 - pru vsourve & harvester
   - fix residue feature
   - remove limiting-behavior of boost-regulator
   - fix calculation of window_size for individual usecases
   - ivcurve - cutout measurements during big step
+  - improve code-quality (cleaner fetching of emu-input and special math-functions are easier to understand)
 - harvesting ivcurves
   - fix max age of samples
   - improve initial interval_step to intake two whole ivcurves before reset
   - improve VOC-harvester
+- python module "shepherd-pru" interfaces pru-c-code via ctypes
+  - harvesting & emulation can be done
+  - benchmarking revealed some bugs
+- remove cython-playground (in favor of ctypes-implementation)
 - ansible: remove py-packages before install
 - extend ruff and fix ~ 200 linting-errors
 - **tested**: pytest sheep, pytest herd, playbook dev_rebuild_sw.yml

--- a/software/firmware/include/commons.h
+++ b/software/firmware/include/commons.h
@@ -152,6 +152,7 @@ struct SampleBuffer
  * 	- pru1 could read ahead, despite a bufferchange
  * 	- python would still fill this fifo block by block, its just easier for the pru to read
  * 	- keep matching V&C / IV Values together -> more efficient for pru
+ *  - report size to python (less hardcoded vars)
  */
 
 /* Programmer-Control as part of SharedMem-Struct */
@@ -368,7 +369,8 @@ struct SharedMem
     /* Counter for ADC-Samples, updated by PRU0, also needed (non-writing) by PRU1 */
     uint32_t                 analog_sample_counter;
     /* Fetch-System where pru0 can instruct pru1 to get the IV-Set from far buffer */
-    uint32_t                 analog_value_index;
+    uint32_t                 analog_value_request; // managed & written by PRU0
+    uint32_t                 analog_value_index;   // these 3 below are managed & written by PRU1
     uint32_t                 analog_value_current;
     uint32_t                 analog_value_voltage;
     /* Token system to ensure both PRUs can share interrupts */

--- a/software/firmware/pru0-module-py/shepherd_pru/data_types.py
+++ b/software/firmware/pru0-module-py/shepherd_pru/data_types.py
@@ -73,7 +73,7 @@ class SharedMemLight(ct.Structure):
         ("gpio_pin_state", ct.c_uint32),
         ("gpio_edges", ct.c_uint32),  # Pointer
         ("sample_buffer", ct.c_uint32),  # Pointer
-        ("analog_x", ct.c_uint32 * 4),
+        ("analog_x", ct.c_uint32 * 5),
         ("trigger_x", ct.c_uint32 * 2),  # bool_ft
         ("vsource_batok_trigger_for_pru1", ct.c_uint32),  # bool_ft
         ("vsource_skip_gpio_logging", ct.c_uint32),  # bool_ft

--- a/software/firmware/pru0-shepherd-fw/include/sampling.h
+++ b/software/firmware/pru0-shepherd-fw/include/sampling.h
@@ -4,7 +4,7 @@
 #include "commons.h"
 
 void     sample_init(const volatile struct SharedMem *shared_mem);
-uint32_t sample(volatile struct SharedMem *shared_mem, struct SampleBuffer *current_buffer_far,
+void     sample(volatile struct SharedMem *shared_mem, struct SampleBuffer *current_buffer_far,
                 enum ShepherdMode mode);
 uint32_t sample_dbg_adc(uint32_t channel_num);
 void     sample_dbg_dac(uint32_t value);

--- a/software/firmware/pru0-shepherd-fw/include/virtual_harvester.h
+++ b/software/firmware/pru0-shepherd-fw/include/virtual_harvester.h
@@ -4,10 +4,10 @@
 #include "commons.h"
 #include "stdint.h"
 
-void     harvester_initialize(const volatile struct HarvesterConfig *);
+void harvester_initialize(const volatile struct HarvesterConfig *);
 
-uint32_t sample_adc_harvester(struct SampleBuffer *buffer, uint32_t sample_idx);
+void sample_adc_harvester(struct SampleBuffer *buffer, uint32_t sample_idx);
 
-void     sample_ivcurve_harvester(uint32_t *p_voltage_uV, uint32_t *p_current_nA);
+void sample_ivcurve_harvester(uint32_t *p_voltage_uV, uint32_t *p_current_nA);
 
 #endif //PRU_FIRMWARE_PRU0_SHEPHERD_FW_HARVESTER_H

--- a/software/firmware/pru0-shepherd-fw/virtual_harvester.c
+++ b/software/firmware/pru0-shepherd-fw/virtual_harvester.c
@@ -107,7 +107,7 @@ void harvester_initialize(const volatile struct HarvesterConfig *const config)
     // TODO: embed cfg->current_limit_nA as a limiter if resources allow for it
 }
 
-uint32_t sample_adc_harvester(struct SampleBuffer *const buffer, const uint32_t sample_idx)
+void sample_adc_harvester(struct SampleBuffer *const buffer, const uint32_t sample_idx)
 {
     if (cfg->algorithm >= HRV_MPPT_PO) harvest_adc_2_mppt_po(buffer, sample_idx);
     else if (cfg->algorithm >= HRV_MPPT_VOC) harvest_adc_2_mppt_voc(buffer, sample_idx);
@@ -117,7 +117,6 @@ uint32_t sample_adc_harvester(struct SampleBuffer *const buffer, const uint32_t 
     else if (cfg->algorithm >= HRV_ISC_VOC) harvest_adc_2_isc_voc(buffer, sample_idx);
 #endif
     // todo: else send error to system
-    return 0u;
 }
 
 static void harvest_adc_2_cv(struct SampleBuffer *const buffer, const uint32_t sample_idx)

--- a/software/firmware/pru1-shepherd-fw/main.c
+++ b/software/firmware/pru1-shepherd-fw/main.c
@@ -414,17 +414,18 @@ int32_t event_loop(volatile struct SharedMem *const shared_mem)
             continue; // for more regular gpio-sampling
         }
 
-        /* Mem-Reading for PRU0 -> can vary from 530 to 5400 ns (rare) */
-        if ((shared_mem->analog_sample_counter != shared_mem->analog_value_index) &&
+        /* Mem-Reading for PRU -> can vary from 530 to 5400 ns (rare) */
+        if ((shared_mem->analog_value_request != shared_mem->analog_value_index) &&
             (shared_mem->sample_buffer != NULL) &&
-            (shared_mem->analog_sample_counter < ADC_SAMPLES_PER_BUFFER))
+            (shared_mem->analog_value_request < ADC_SAMPLES_PER_BUFFER))
         {
             // split reads to optimize gpio-tracing
-            static bool_ft first = true;
+            static bool_ft first       = true;
+            const uint32_t value_index = shared_mem->analog_value_request;
+
             if (first)
             {
                 DEBUG_RAMRD_STATE_1;
-                const uint32_t value_index = shared_mem->analog_sample_counter;
                 shared_mem->analog_value_current =
                         shared_mem->sample_buffer->values_current[value_index];
                 first = false;
@@ -432,7 +433,6 @@ int32_t event_loop(volatile struct SharedMem *const shared_mem)
             else
             {
                 DEBUG_RAMRD_STATE_2;
-                const uint32_t value_index = shared_mem->analog_sample_counter;
                 shared_mem->analog_value_voltage =
                         shared_mem->sample_buffer->values_voltage[value_index];
                 shared_mem->analog_value_index = value_index;


### PR DESCRIPTION
- big bugfix release
- sheep
  - limit pru-warning count
  - fix forced stopping of ntp-service
  - improve debug-output
  - fix ingestion of ivcurves (windowsize was not propagated)
  - fix copy of emu-input into shared mem (off-by-one-error)
- herd
  - query for alive status of testbed (all hosts responding)
  - more robust unittesting
  - add automated benchmark in `software\shepherd-herd\test_manual\`
- python in general
  - add progress-bars to long processes
  - remove progress-bar after task finishes (most)
  - don't limit pandas to <v2 anymore
  - prepare for py313
- pru vsourve & harvester
  - fix residue feature
  - remove limiting-behavior of boost-regulator
  - fix calculation of window_size for individual usecases
  - ivcurve - cutout measurements during big step
  - improve code-quality (cleaner fetching of emu-input and special math-functions are easier to understand)
- harvesting ivcurves
  - fix max age of samples
  - improve initial interval_step to intake two whole ivcurves before reset
  - improve VOC-harvester
- python module "shepherd-pru" interfaces pru-c-code via ctypes
  - harvesting & emulation can be done
  - benchmarking revealed some bugs
- remove cython-playground (in favor of ctypes-implementation)
- ansible: remove py-packages before install
- extend ruff and fix ~ 200 linting-errors
- **tested**: pytest sheep, pytest herd, playbook dev_rebuild_sw.yml