### PR TITLE
Dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.5.7'
+    rev: 'v0.6.0'
     hooks:
       - id: ruff-format
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # History of Changes
 
+## 0.8.2
+
+- PRU gets now partially zeroed buffer-segments
+- PRU had a race-condition with a loose mutex resulting in keeping old gpio-samples
+- python now warns on full gpio-buffer (as it can only hold ~16k entries in 100 ms)
+- python now warns if first or last timestamp of gpio-buffer is out of scope of outer buffer-period
+
 ## 0.8.1
 
 - big bugfix release

--- a/software/firmware/pru0-module-py/examples/emulate.py
+++ b/software/firmware/pru0-module-py/examples/emulate.py
@@ -7,7 +7,6 @@ from shepherd_core.vsource import ResistiveTarget
 from shepherd_data import Reader
 from shepherd_pru.pru_source_simulation import simulate_source
 
-
 hrv_list = [
     "ivcurve",
     "mppt_voc",

--- a/software/firmware/pru1-shepherd-fw/main.c
+++ b/software/firmware/pru1-shepherd-fw/main.c
@@ -207,7 +207,7 @@ static inline void check_gpio(volatile struct SharedMem *const shared_mem,
 
         /* Each buffer can only store a limited number of events */
         if (cIDX >= MAX_GPIO_EVT_PER_BUFFER) return;
-        // TODO: indicate overflow here before returning. ie. MAX_GPIO.. + 1
+        // TODO: could indicate overflow here before returning. ie. MAX_GPIO.. + 1
 
         /* Ticks since we've taken the last sample */
         const uint32_t ticks_since_last_sample = CT_IEP.TMR_CNT - last_sample_ticks;

--- a/software/firmware/pru1-shepherd-fw/main.c
+++ b/software/firmware/pru1-shepherd-fw/main.c
@@ -202,11 +202,16 @@ static inline void check_gpio(volatile struct SharedMem *const shared_mem,
     if (gpio_diff > 0)
     {
         DEBUG_GPIO_STATE_2;
+        simple_mutex_enter(&shared_mem->gpio_edges_mutex);
         // local copy reduces reads to far-ram to current minimum
         const uint32_t cIDX = shared_mem->gpio_edges->idx;
 
         /* Each buffer can only store a limited number of events */
-        if (cIDX >= MAX_GPIO_EVT_PER_BUFFER) return;
+        if (cIDX >= MAX_GPIO_EVT_PER_BUFFER)
+        {
+            simple_mutex_exit(&shared_mem->gpio_edges_mutex);
+            return;
+        }
         // TODO: could indicate overflow here before returning. ie. MAX_GPIO.. + 1
 
         /* Ticks since we've taken the last sample */
@@ -215,7 +220,6 @@ static inline void check_gpio(volatile struct SharedMem *const shared_mem,
         const uint64_t gpio_timestamp_ns =
                 shared_mem->last_sample_timestamp_ns + TIMER_TICK_NS * ticks_since_last_sample;
 
-        simple_mutex_enter(&shared_mem->gpio_edges_mutex);
         shared_mem->gpio_edges->timestamp_ns[cIDX] = gpio_timestamp_ns;
         shared_mem->gpio_edges->bitmask[cIDX]      = (uint16_t) gpio_status;
         shared_mem->gpio_edges->idx                = cIDX + 1u;

--- a/software/python-package/shepherd_sheep/shared_memory.py
+++ b/software/python-package/shepherd_sheep/shared_memory.py
@@ -142,6 +142,10 @@ class SharedMemory:
         self.gpio_ts_offset = self.gpio_offset + 4 + 4
         self.gpio_vl_offset = self.gpio_offset + 8 + 8 * commons.MAX_GPIO_EVT_PER_BUFFER
         self.pru0_ut_offset = self.gpio_offset + 8 + 10 * commons.MAX_GPIO_EVT_PER_BUFFER
+        # init zeroed data for clearing buffers
+        self.zero_4b = bytes(bytearray(4))
+        self.zero_8b = bytes(bytearray(8))
+        self.zero_gpio_ts = commons.MAX_GPIO_EVT_PER_BUFFER * self.zero_8b
 
         log.debug("Size of 1 Buffer:\t%d byte", self.buffer_size)
         if self.buffer_size * self.n_buffers != self.size:
@@ -164,6 +168,9 @@ class SharedMemory:
         )
 
     def __enter__(self) -> Self:
+        # zero parts of buffer as a precaution
+        for idx in range(self.n_buffers):
+            self.clear_buffer(idx)
         return self
 
     def __exit__(
@@ -303,7 +310,10 @@ class SharedMemory:
             )
 
         if n_gpio_events == commons.MAX_GPIO_EVT_PER_BUFFER:
-            log.warning("Hint for Overflow - current GPIO-Buffer is full @ buffer-ts = %.1f s", buffer_timestamp / 1e9)
+            log.warning(
+                "Hint for Overflow - current GPIO-Buffer is full @ buffer-ts = %.1f s",
+                buffer_timestamp / 1e9,
+            )
         if not (0 <= n_gpio_events <= commons.MAX_GPIO_EVT_PER_BUFFER):
             log.error(
                 "Size of gpio_events out of range with %d entries (max=%d)",
@@ -367,6 +377,18 @@ class SharedMemory:
             pru0_util_mean,
             pru0_util_max,
         )
+
+    def clear_buffer(self, index: int) -> None:
+        # this fn should be executed before handing the buffer back to PRU
+        buffer_offset = self.buffer_size * index
+        # IV-Sample len & timestamp
+        self.mapped_mem.seek(buffer_offset + 4)  # behind canary
+        self.mapped_mem.write(self.zero_4b)  # len
+        self.mapped_mem.write(self.zero_8b)  # timestamp
+        # GPIO-Edges-Index & timestamps
+        self.mapped_mem.seek(buffer_offset + self.gpio_offset + 4)  # behind canary
+        self.mapped_mem.write(self.zero_4b)  # idx
+        self.mapped_mem.write(self.zero_gpio_ts)  # timestamp-array
 
     def write_buffer(
         self,

--- a/software/python-package/shepherd_sheep/shared_memory.py
+++ b/software/python-package/shepherd_sheep/shared_memory.py
@@ -340,6 +340,15 @@ class SharedMemory:
             gpio_timestamps_ns = np.empty(0, dtype=np.uint64)
             gpio_values = np.empty(0, dtype=np.uint16)
 
+        if len(gpio_timestamps_ns) > 0:
+            # test if first/last gpio-timestamp is in scope of outer buffer
+            gpio_ts_valid = ((buffer_timestamp <= gpio_timestamps_ns[0] <= buffer_timestamp + 100e6) and
+                             (buffer_timestamp <= gpio_timestamps_ns[-1] <= buffer_timestamp + 100e6))
+            if not gpio_ts_valid:
+                log.warning("Timestamps (first or last) of GPIO-buffer are NOT in buffer-period @ ts = %.1f s",
+                            buffer_timestamp / 1e9,
+                            )
+
         gpio_edges = GPIOEdges(gpio_timestamps_ns, gpio_values)
 
         # pru0 util

--- a/software/python-package/shepherd_sheep/shared_memory.py
+++ b/software/python-package/shepherd_sheep/shared_memory.py
@@ -342,12 +342,13 @@ class SharedMemory:
 
         if len(gpio_timestamps_ns) > 0:
             # test if first/last gpio-timestamp is in scope of outer buffer
-            gpio_ts_valid = ((buffer_timestamp <= gpio_timestamps_ns[0] <= buffer_timestamp + 100e6) and
-                             (buffer_timestamp <= gpio_timestamps_ns[-1] <= buffer_timestamp + 100e6))
-            if not gpio_ts_valid:
-                log.warning("Timestamps (first or last) of GPIO-buffer are NOT in buffer-period @ ts = %.1f s",
-                            buffer_timestamp / 1e9,
-                            )
+            ts1_valid = buffer_timestamp <= gpio_timestamps_ns[0] <= buffer_timestamp + 100e6
+            ts2_valid = buffer_timestamp <= gpio_timestamps_ns[-1] <= buffer_timestamp + 100e6
+            if not (ts1_valid and ts2_valid):
+                log.warning(
+                    "Timestamps of GPIO-buffer are out of scope of outer buffer-period @ ts = %.1f s",
+                    buffer_timestamp / 1e9,
+                )
 
         gpio_edges = GPIOEdges(gpio_timestamps_ns, gpio_values)
 

--- a/software/python-package/shepherd_sheep/shared_memory.py
+++ b/software/python-package/shepherd_sheep/shared_memory.py
@@ -302,6 +302,8 @@ class SharedMemory:
                 f"CANARY of GpioBuffer was harmed! Is 0x{canary2:X}, expected 0x0F0F0F0F",
             )
 
+        if n_gpio_events == commons.MAX_GPIO_EVT_PER_BUFFER:
+            log.warning("Hint for Overflow - current GPIO-Buffer is full @ buffer-ts = %.1f s", buffer_timestamp / 1e9)
         if not (0 <= n_gpio_events <= commons.MAX_GPIO_EVT_PER_BUFFER):
             log.error(
                 "Size of gpio_events out of range with %d entries (max=%d)",

--- a/software/python-package/shepherd_sheep/shared_memory.py
+++ b/software/python-package/shepherd_sheep/shared_memory.py
@@ -311,7 +311,7 @@ class SharedMemory:
 
         if n_gpio_events == commons.MAX_GPIO_EVT_PER_BUFFER:
             log.warning(
-                "Hint for Overflow - current GPIO-Buffer is full @ buffer-ts = %.1f s",
+                "Current GPIO-Buffer is full @ buffer-ts = %.1f s -> hint for overflow & loss of data",
                 buffer_timestamp / 1e9,
             )
         if not (0 <= n_gpio_events <= commons.MAX_GPIO_EVT_PER_BUFFER):

--- a/software/python-package/shepherd_sheep/shepherd_emulator.py
+++ b/software/python-package/shepherd_sheep/shepherd_emulator.py
@@ -212,6 +212,7 @@ class ShepherdEmulator(ShepherdIO):
         v_tf = self.cal_pru.voltage.raw_to_si(buffer.voltage).astype("u4")
         c_tf = self.cal_pru.current.raw_to_si(buffer.current).astype("u4")
 
+        self.shared_mem.clear_buffer(index)
         self.shared_mem.write_buffer(index, v_tf, c_tf)
         super()._return_buffer(index)
         if verbose:

--- a/software/python-package/shepherd_sheep/shepherd_harvester.py
+++ b/software/python-package/shepherd_sheep/shepherd_harvester.py
@@ -131,6 +131,7 @@ class ShepherdHarvester(ShepherdIO):
         :param index: (int) Index of the buffer. 0 <= index < n_buffers
         :param verbose: chatter-prevention, performance-critical computation saver
         """
+        self.shared_mem.clear_buffer(index)
         super()._return_buffer(index)
         if verbose:
             log.debug("Sent empty buffer #%s to PRU", index)

--- a/software/python-package/tests/conftest.py
+++ b/software/python-package/tests/conftest.py
@@ -65,13 +65,13 @@ def pytest_collection_modifyitems(
             item.add_marker(skip_mock)
 
 
-@pytest.fixture()
+@pytest.fixture
 def _shepherd_down(fake_fs: FakeFilesystem | None) -> None:
     if fake_fs is None:
         remove_kernel_module()
 
 
-@pytest.fixture()
+@pytest.fixture
 def _shepherd_up(
     _shepherd_down: None,
     fake_fs: FakeFilesystem | None,
@@ -112,6 +112,6 @@ def _shepherd_up(
         gc.collect()  # precaution
 
 
-@pytest.fixture()
+@pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner()

--- a/software/python-package/tests/test__files.py
+++ b/software/python-package/tests/test__files.py
@@ -13,7 +13,7 @@ from shepherd_core.data_models.task import EmulationTask
 from shepherd_core.data_models.task import HarvestTask
 
 
-@pytest.fixture()
+@pytest.fixture
 def path_here() -> Path:
     return Path(__file__).resolve().parent
 

--- a/software/python-package/tests/test_cli_misc.py
+++ b/software/python-package/tests/test_cli_misc.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from shepherd_sheep.cli import cli
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_target_power_min_arg_a(
@@ -20,7 +20,7 @@ def test_cli_target_power_min_arg_a(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_target_power_min_arg_b(
@@ -38,7 +38,7 @@ def test_cli_target_power_min_arg_b(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_target_power_min_arg_c(
@@ -56,7 +56,7 @@ def test_cli_target_power_min_arg_c(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_target_power_explicit_a(
@@ -75,7 +75,7 @@ def test_cli_target_power_explicit_a(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_target_power_explicit_b(
@@ -96,7 +96,7 @@ def test_cli_target_power_explicit_b(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_eeprom_read_min_arg_a(
@@ -112,7 +112,7 @@ def test_cli_eeprom_read_min_arg_a(
     assert res.exit_code in {0, 2, 3}
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_eeprom_read_min_arg_b(
@@ -135,7 +135,7 @@ def test_cli_eeprom_read_min_arg_b(
     assert res.exit_code in {0, 2, 3}
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_eeprom_read_explicit(
@@ -158,7 +158,7 @@ def test_cli_eeprom_read_explicit(
     assert res.exit_code in {0, 2, 3}
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_inventorize_min_arg_a(
@@ -171,7 +171,7 @@ def test_cli_inventorize_min_arg_a(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_inventorize_min_arg_b(
@@ -187,7 +187,7 @@ def test_cli_inventorize_min_arg_b(
     assert file.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_inventorize_explicit(
@@ -203,7 +203,7 @@ def test_cli_inventorize_explicit(
     assert file.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_fix_kmod(

--- a/software/python-package/tests/test_cli_programmer.py
+++ b/software/python-package/tests/test_cli_programmer.py
@@ -8,21 +8,21 @@ from shepherd_sheep.cli import cli
 # differences: import _herd, .mark.hardware, shepherd_up / stopped_herd
 
 
-@pytest.fixture()
+@pytest.fixture
 def fw_nrf() -> Path:
     here = Path(__file__).resolve()
     name = "firmware_nrf52_testable.hex"
     return here.parent / name
 
 
-@pytest.fixture()
+@pytest.fixture
 def fw_msp() -> Path:
     here = Path(__file__).resolve()
     name = "firmware_msp430_testable.hex"
     return here.parent / name
 
 
-@pytest.fixture()
+@pytest.fixture
 def fw_empty(tmp_path: Path) -> Path:
     store_path = tmp_path / "firmware_null.hex"
     with store_path.resolve().open("w", encoding="utf-8-sig") as fh:
@@ -30,7 +30,7 @@ def fw_empty(tmp_path: Path) -> Path:
     return store_path
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_minimal(
@@ -49,7 +49,7 @@ def test_cli_program_minimal(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_swd_explicit(
@@ -78,7 +78,7 @@ def test_cli_program_swd_explicit(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_swd_explicit_short(
@@ -107,7 +107,7 @@ def test_cli_program_swd_explicit_short(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_sbw_explicit(
@@ -136,7 +136,7 @@ def test_cli_program_sbw_explicit(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_file_defective_a(
@@ -155,7 +155,7 @@ def test_cli_program_file_defective_a(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_file_defective_b(
@@ -174,7 +174,7 @@ def test_cli_program_file_defective_b(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_file_defective_c(
@@ -193,7 +193,7 @@ def test_cli_program_file_defective_c(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_datarate_invalid_a(
@@ -214,7 +214,7 @@ def test_cli_program_datarate_invalid_a(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_datarate_invalid_b(
@@ -235,7 +235,7 @@ def test_cli_program_datarate_invalid_b(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_program_target_invalid(

--- a/software/python-package/tests/test_cli_run_task.py
+++ b/software/python-package/tests/test_cli_run_task.py
@@ -36,7 +36,7 @@ def random_data(length: int) -> np.ndarray:
     return rng.integers(low=0, high=2**18, size=length, dtype="u4")
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_h5(tmp_path: Path) -> Path:
     store_path = tmp_path / "harvest_example.h5"
     with Writer(
@@ -52,22 +52,22 @@ def data_h5(tmp_path: Path) -> Path:
     return store_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def tmp_yaml(tmp_path: Path) -> Path:
     return tmp_path / "cfg.yaml"
 
 
-@pytest.fixture()
+@pytest.fixture
 def path_h5(tmp_path: Path) -> Path:
     return tmp_path / "out.h5"
 
 
-@pytest.fixture()
+@pytest.fixture
 def path_here() -> Path:
     return Path(__file__).resolve().parent
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_harvest_no_cal(
@@ -87,7 +87,7 @@ def test_cli_harvest_no_cal(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_harvest_parameters_most(
@@ -109,7 +109,7 @@ def test_cli_harvest_parameters_most(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_harvest_parameters_minimal(
@@ -128,7 +128,7 @@ def test_cli_harvest_parameters_minimal(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_harvest_preconfigured(
@@ -140,7 +140,7 @@ def test_cli_harvest_preconfigured(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_harvest_preconf_etc_shp_examples(
@@ -152,7 +152,7 @@ def test_cli_harvest_preconf_etc_shp_examples(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate(
@@ -180,7 +180,7 @@ def test_cli_emulate(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_with_custom_virtsource(
@@ -213,7 +213,7 @@ def test_cli_emulate_with_custom_virtsource(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_with_bq25570(
@@ -242,7 +242,7 @@ def test_cli_emulate_with_bq25570(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_aux_voltage(
@@ -271,7 +271,7 @@ def test_cli_emulate_aux_voltage(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_parameters_long(
@@ -308,7 +308,7 @@ def test_cli_emulate_parameters_long(
     assert path_h5.exists()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_parameters_minimal(
@@ -332,7 +332,7 @@ def test_cli_emulate_parameters_minimal(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_preconfigured(
@@ -344,7 +344,7 @@ def test_cli_emulate_preconfigured(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(80)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_preconf_etc_shp_examples(
@@ -357,7 +357,7 @@ def test_cli_emulate_preconf_etc_shp_examples(
     assert res.exit_code == 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_emulate_aux_voltage_fail(
@@ -384,7 +384,7 @@ def test_cli_emulate_aux_voltage_fail(
     assert res.exit_code != 0
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_fw_mod_task(
@@ -419,7 +419,7 @@ def test_cli_fw_mod_task(
     assert path_file.is_file()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.timeout(60)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_cli_programming(

--- a/software/python-package/tests/test_datalogging.py
+++ b/software/python-package/tests/test_datalogging.py
@@ -18,7 +18,7 @@ def random_data(length: int) -> np.ndarray:
     return rng.integers(low=0, high=2**18, size=length, dtype="u4")
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_buffer() -> DataBuffer:
     len_ = 10_000
     voltage = random_data(len_)
@@ -26,7 +26,7 @@ def data_buffer() -> DataBuffer:
     return DataBuffer(voltage, current, 1551848387472)
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_h5(tmp_path: Path) -> Path:
     name = tmp_path / "record_example.h5"
     with Writer(name, cal_data=CalibrationHarvester(), force_overwrite=True) as store:
@@ -38,7 +38,7 @@ def data_h5(tmp_path: Path) -> Path:
     return name
 
 
-@pytest.fixture()
+@pytest.fixture
 def cal_cape() -> CalibrationCape:
     return CalibrationCape()
 

--- a/software/python-package/tests/test_eeprom.py
+++ b/software/python-package/tests/test_eeprom.py
@@ -7,22 +7,22 @@ from shepherd_core.data_models.base.calibration import CapeData
 from shepherd_sheep import EEPROM
 
 
-@pytest.fixture()
+@pytest.fixture
 def cal_cape() -> CalibrationCape:
     return CalibrationCape()
 
 
-@pytest.fixture()
+@pytest.fixture
 def cape_data() -> CapeData:
     return CapeData(serial_number="011900000001", version="00A0")
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_test_string() -> bytes:
     return b"test content"
 
 
-@pytest.fixture()
+@pytest.fixture
 def eeprom_open(
     request: pytest.FixtureRequest,
     fake_fs: FakeFilesystem | None,
@@ -39,7 +39,7 @@ def eeprom_open(
         yield eeprom
 
 
-@pytest.fixture()
+@pytest.fixture
 def eeprom_retained(eeprom_open: EEPROM) -> Generator[EEPROM, None, None]:
     data = eeprom_open._read(0, 1024)
     for i in range(256):
@@ -48,7 +48,7 @@ def eeprom_retained(eeprom_open: EEPROM) -> Generator[EEPROM, None, None]:
     eeprom_open._write(0, data)
 
 
-@pytest.fixture()
+@pytest.fixture
 def eeprom_with_data(
     eeprom_retained: EEPROM,
     cape_data: CapeData,
@@ -57,7 +57,7 @@ def eeprom_with_data(
     return eeprom_retained
 
 
-@pytest.fixture()
+@pytest.fixture
 def eeprom_with_calibration(
     eeprom_retained: EEPROM,
     cal_cape: CalibrationCape,
@@ -66,30 +66,30 @@ def eeprom_with_calibration(
     return eeprom_retained
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_read_raw(eeprom_open: EEPROM) -> None:
     eeprom_open._read(0, 4)
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_write_raw(eeprom_retained: EEPROM, data_test_string: bytes) -> None:
     eeprom_retained._write(0, data_test_string)
     data = eeprom_retained._read(0, len(data_test_string))
     assert data == data_test_string
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_read_value(eeprom_with_data: EEPROM, cape_data: CapeData) -> None:
     with pytest.raises(KeyError):
         _ = eeprom_with_data["some non-sense parameter"]
     assert eeprom_with_data["version"] == cape_data["version"]
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_write_value(eeprom_retained: EEPROM, cape_data: CapeData) -> None:
     with pytest.raises(KeyError):
         eeprom_retained["some non-sense parameter"] = "some data"
@@ -98,8 +98,8 @@ def test_write_value(eeprom_retained: EEPROM, cape_data: CapeData) -> None:
     assert eeprom_retained["version"] == "1234"
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_write_capedata(eeprom_retained: EEPROM, cape_data: CapeData) -> None:
     eeprom_retained._write_cape_data(cape_data)
     for key, value in cape_data.items():
@@ -109,16 +109,16 @@ def test_write_capedata(eeprom_retained: EEPROM, cape_data: CapeData) -> None:
             assert eeprom_retained[key] == value
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_read_capedata(eeprom_with_data: EEPROM, cape_data: CapeData) -> None:
     cape_data2 = eeprom_with_data._read_cape_data()
     for key, _ in cape_data:
         assert cape_data[key] == cape_data2[key]
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_write_calibration(eeprom_retained: EEPROM, cal_cape: CalibrationCape) -> None:
     eeprom_retained.write_calibration(cal_cape)
     cal_restored = eeprom_retained.read_calibration()
@@ -126,8 +126,8 @@ def test_write_calibration(eeprom_retained: EEPROM, cal_cape: CalibrationCape) -
         assert cal_restored[component].get_hash() == cal_cape[component].get_hash()
 
 
-@pytest.mark.eeprom_write()
-@pytest.mark.hardware()
+@pytest.mark.eeprom_write
+@pytest.mark.hardware
 def test_read_calibration(
     eeprom_with_calibration: EEPROM,
     cal_cape: CalibrationCape,

--- a/software/python-package/tests/test_emulation.py
+++ b/software/python-package/tests/test_emulation.py
@@ -25,7 +25,7 @@ def random_data(length: int) -> np.ndarray:
     return rng.integers(low=0, high=2**18, size=length, dtype="u4")
 
 
-@pytest.fixture()
+@pytest.fixture
 def src_cfg() -> VirtualSourceConfig:
     here = Path(__file__).resolve()
     name = "_test_config_virtsource.yaml"
@@ -33,7 +33,7 @@ def src_cfg() -> VirtualSourceConfig:
     return VirtualSourceConfig.from_file(file_path)
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_h5(tmp_path: Path) -> Path:
     store_path = tmp_path / "record_example.h5"
     with Writer(
@@ -49,7 +49,7 @@ def data_h5(tmp_path: Path) -> Path:
     return store_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def writer(tmp_path: Path) -> Generator[Writer, None, None]:
     cal = CalibrationCape().emulator
     with Writer(
@@ -61,13 +61,13 @@ def writer(tmp_path: Path) -> Generator[Writer, None, None]:
         yield _w
 
 
-@pytest.fixture()
+@pytest.fixture
 def shp_reader(data_h5: Path) -> Generator[CoreReader, None, None]:
     with CoreReader(data_h5) as _r:
         yield _r
 
 
-@pytest.fixture()
+@pytest.fixture
 def emulator(
     _shepherd_up: None,
     data_h5: Path,
@@ -82,7 +82,7 @@ def emulator(
         yield _e
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 def test_emulation(
     writer: Writer,
     shp_reader: CoreReader,
@@ -105,7 +105,7 @@ def test_emulation(
         _, _ = emulator.get_buffer()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_emulate_fn(tmp_path: Path, data_h5: Path) -> None:
     output = tmp_path / "rec.h5"
@@ -133,7 +133,7 @@ def test_emulate_fn(tmp_path: Path, data_h5: Path) -> None:
         )
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.skip(reason="REQUIRES CAPE HARDWARE v2.4")  # real cape needed
 @pytest.mark.usefixtures("_shepherd_up")
 def test_target_pins() -> None:

--- a/software/python-package/tests/test_harvest.py
+++ b/software/python-package/tests/test_harvest.py
@@ -17,7 +17,7 @@ def mode(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def writer(tmp_path: Path, mode: str) -> Generator[Writer, None, None]:
     with Writer(
         mode=mode,
@@ -28,7 +28,7 @@ def writer(tmp_path: Path, mode: str) -> Generator[Writer, None, None]:
         yield _w
 
 
-@pytest.fixture()
+@pytest.fixture
 def harvester(
     _shepherd_up: None,
     mode: str,
@@ -39,7 +39,7 @@ def harvester(
         yield _h
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_instantiation(tmp_path: Path) -> None:
     cfg = HarvestTask(output_path=tmp_path / "hrv_123.h5")
@@ -48,7 +48,7 @@ def test_instantiation(tmp_path: Path) -> None:
     del _h
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 def test_harvester(writer: Writer, harvester: ShepherdHarvester) -> None:
     harvester.start(wait_blocking=False)
     harvester.wait_for_start(15)
@@ -59,7 +59,7 @@ def test_harvester(writer: Writer, harvester: ShepherdHarvester) -> None:
         harvester.return_buffer(idx)
 
 
-@pytest.mark.hardware()  # TODO: extend with new harvester-options
+@pytest.mark.hardware  # TODO: extend with new harvester-options
 @pytest.mark.timeout(40)
 @pytest.mark.usefixtures("_shepherd_up")
 def test_harvester_fn(tmp_path: Path) -> None:

--- a/software/python-package/tests/test_sysfs_interface.py
+++ b/software/python-package/tests/test_sysfs_interface.py
@@ -12,7 +12,7 @@ from shepherd_sheep import flatten_list
 from shepherd_sheep import sysfs_interface
 
 
-@pytest.fixture()
+@pytest.fixture
 def cnv_cfg() -> ConverterPRUConfig:
     here = Path(__file__).resolve()
     name = "_test_config_virtsource.yaml"
@@ -21,20 +21,20 @@ def cnv_cfg() -> ConverterPRUConfig:
     return ConverterPRUConfig.from_vsrc(src_cfg, log_intermediate_node=False)
 
 
-@pytest.fixture()
+@pytest.fixture
 def hrv_cfg() -> HarvesterPRUConfig:
     path = Path(__file__).parent / "_test_config_harvest.yaml"
     hrv_cfg = HarvestTask.from_file(path.as_posix())
     return HarvesterPRUConfig.from_vhrv(hrv_cfg.virtual_harvester)
 
 
-@pytest.fixture()
+@pytest.fixture
 def _shepherd_running(_shepherd_up: None) -> None:
     sysfs_interface.set_start()
     sysfs_interface.wait_for_state("running", 5)
 
 
-@pytest.fixture()
+@pytest.fixture
 def cal4sysfs() -> dict:
     cal = CalibrationCape()
     return cal.emulator.export_for_sysfs()
@@ -55,7 +55,7 @@ def test_getters_fail(attr: str) -> None:
         method_to_call()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_start() -> None:
     sysfs_interface.set_start()
@@ -65,7 +65,7 @@ def test_start() -> None:
         sysfs_interface.set_start()
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_wait_for_state() -> None:
     sysfs_interface.set_start()
@@ -74,7 +74,7 @@ def test_wait_for_state() -> None:
     assert sysfs_interface.wait_for_state("idle", 3) < 3
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_start_delayed() -> None:
     start_time = int(time.time() + 5)
@@ -103,7 +103,7 @@ def test_initial_mode() -> None:
     assert sysfs_interface.get_mode() == "harvester"
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_running")
 def test_set_mode_fail_offline() -> None:
     with pytest.raises(sysfs_interface.SysfsInterfaceError):
@@ -144,7 +144,7 @@ def test_calibration_settings(cal4sysfs: dict) -> None:
     assert sysfs_interface.read_calibration_settings() == cal4sysfs
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_initial_calibration_settings(cal4sysfs: dict) -> None:
     # NOTE: initial config is in common_inits.h of kernel-module
@@ -157,14 +157,14 @@ def test_initial_calibration_settings(cal4sysfs: dict) -> None:
     assert sysfs_interface.read_calibration_settings() == cal4sysfs
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_initial_harvester_settings() -> None:
     hrv_list = [0, *list(range(200, 211))]
     assert sysfs_interface.read_virtual_harvester_settings() == hrv_list
 
 
-@pytest.mark.hardware()  # TODO: could also run with mock_hardware, but triggers pydantic-error
+@pytest.mark.hardware  # TODO: could also run with mock_hardware, but triggers pydantic-error
 @pytest.mark.usefixtures("_shepherd_up")
 def test_writing_harvester_settings(
     hrv_cfg: HarvesterPRUConfig,
@@ -175,7 +175,7 @@ def test_writing_harvester_settings(
     )
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_initial_virtsource_settings() -> None:
     # NOTE: initial config is set in main() of pru0

--- a/software/python-package/tests/test_virtual_source.py
+++ b/software/python-package/tests/test_virtual_source.py
@@ -10,7 +10,7 @@ from shepherd_core.vsource import VirtualSourceModel
 from shepherd_sheep import ShepherdDebug
 
 
-@pytest.fixture()
+@pytest.fixture
 def src_cfg(request: pytest.FixtureRequest) -> VirtualSourceConfig:
     marker = request.node.get_closest_marker("src_name")
     src_name = None if marker is None else marker.args[0]
@@ -27,12 +27,12 @@ def src_cfg(request: pytest.FixtureRequest) -> VirtualSourceConfig:
     raise AssertionError
 
 
-@pytest.fixture()
+@pytest.fixture
 def cal_cape() -> CalibrationCape:
     return CalibrationCape()
 
 
-@pytest.fixture()
+@pytest.fixture
 def pru_vsource(
     _shepherd_up: None,
     src_cfg: VirtualSourceConfig,
@@ -51,7 +51,7 @@ def pru_vsource(
         yield _d
 
 
-@pytest.fixture()
+@pytest.fixture
 def pyt_vsource(
     src_cfg: VirtualSourceConfig,
     cal_cape: CalibrationCape,
@@ -66,7 +66,7 @@ def pyt_vsource(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def reference_vss() -> dict:
     # keep in sync with "_test_config_virtsource.yaml"
     return {
@@ -86,7 +86,7 @@ def difference_percent(val1: float, val2: float, offset: float) -> float:
     return round(100 * abs((val1 + offset) / (val2 + offset) - 1), 3)
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.src_name("./_test_config_virtsource.yaml")
 def test_vsource_add_charge(
     pru_vsource: ShepherdDebug,
@@ -143,7 +143,7 @@ def test_vsource_add_charge(
     assert deviation_rel < 1.0  # %
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.src_name("./_test_config_virtsource.yaml")
 def test_vsource_drain_charge(
     pru_vsource: ShepherdDebug,
@@ -221,7 +221,7 @@ def test_vsource_drain_charge(
     assert V_out_pyt_raw < 1
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.src_name("direct")  # easiest case: v_inp == v_out, current not
 def test_vsource_direct(
     pru_vsource: ShepherdDebug,
@@ -239,7 +239,7 @@ def test_vsource_direct(
         assert difference_percent(V_pyt_mV, voltage_mV, 50) < 3
 
 
-@pytest.mark.hardware()
+@pytest.mark.hardware
 @pytest.mark.src_name("diode+capacitor")
 def test_vsource_diodecap(
     pru_vsource: ShepherdDebug,

--- a/software/shepherd-herd/tests/conftest.py
+++ b/software/shepherd-herd/tests/conftest.py
@@ -11,7 +11,7 @@ from shepherd_herd import Herd
 from shepherd_herd.herd_cli import cli
 
 
-@pytest.fixture()
+@pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner()
 
@@ -58,12 +58,12 @@ def generate_h5_file(file_path: Path, file_name: str = "harvest_example.h5") -> 
     return store_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_h5_path(tmp_path: Path) -> Path:
     return generate_h5_file(tmp_path)
 
 
-@pytest.fixture()
+@pytest.fixture
 def local_herd(tmp_path: Path) -> Path:
     # locations copied from herd.cli()
     inventories = [
@@ -83,7 +83,7 @@ def local_herd(tmp_path: Path) -> Path:
     return local_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def _herd_alive() -> None:
     # pre-test is good for start of new test-file
     for _ in range(3):
@@ -95,7 +95,7 @@ def _herd_alive() -> None:
     raise RuntimeError("No Sheep seems to be alive")
 
 
-@pytest.fixture()
+@pytest.fixture
 def _herd_stopped(cli_runner: CliRunner, _herd_alive: None) -> None:
     cli_runner.invoke(cli, ["-v", "stop"])
     wait_for_end(cli_runner)

--- a/software/shepherd-herd/tests/test_cli_programmer.py
+++ b/software/shepherd-herd/tests/test_cli_programmer.py
@@ -8,14 +8,14 @@ from shepherd_herd.herd_cli import cli
 # differences: import _herd, .mark.hardware, shepherd_up / stopped_herd
 
 
-@pytest.fixture()
+@pytest.fixture
 def fw_example() -> Path:
     here = Path(__file__).absolute()
     name = "firmware_nrf52_powered.hex"
     return here.parent / name
 
 
-@pytest.fixture()
+@pytest.fixture
 def fw_empty(tmp_path: Path) -> Path:
     store_path = tmp_path / "firmware_null.hex"
     with store_path.open("w", encoding="utf-8-sig") as f:


### PR DESCRIPTION
attempted to fix #57 with multiple approaches:
- PRU gets now partially zeroed buffer-segements
- PRU had a race-condition with a loose mutex resulting in keeping old gpio-samples
- python now warns on full gpio-buffer (as it can only hold 16k entries in 100 ms)
- python now warns if first or last timestamp of gpio-buffer is out of scope of outer buffer-segment-period