### PR TITLE
fix logging via journalctl for py < 3.11

### DIFF
--- a/deploy/dev_rebuild_sw.yml
+++ b/deploy/dev_rebuild_sw.yml
@@ -2,7 +2,7 @@
 # hot-swaps pru-firmware (& kernel-module & py-package) by compiling and flashing without restart
 
 - name: Refresh Src, compile and install PRU-Fw, restart Kernel-Module, reinstall py-package, without Reboot
-  hosts: all
+  hosts: sheep
   become: true
 
   vars_prompt:

--- a/software/python-package/shepherd_sheep/h5_monitor_kernel.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_kernel.py
@@ -80,6 +80,10 @@ class KernelMonitor(Monitor):
                 continue
             first_space = line.find(" ")
             time_str = line[:first_space]
+            time_str = time_str[:-2] + ":" + time_str[-2:]
+            # TODO: workaround for py < 3.11, .fromisoformat() can handle
+            #       YYYY-MM-DDTHH:MM:SS+HH:MM, BUT NOT
+            #       YYYY-MM-DDTHH:MM:SS+HHMM (default from --output=short-iso-precise
             time_ts = datetime.fromisoformat(time_str)
             time_ns = int(datetime.timestamp(time_ts) * 1e9)
             line = line[first_space:].strip()[:128]

--- a/software/python-package/shepherd_sheep/h5_monitor_ntp.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_ntp.py
@@ -81,6 +81,10 @@ class NTPMonitor(Monitor):
                 continue
             first_space = line.find(" ")
             time_str = line[:first_space]
+            time_str = time_str[:-2] + ":" + time_str[-2:]
+            # TODO: workaround for py < 3.11, .fromisoformat() can handle
+            #       YYYY-MM-DDTHH:MM:SS+HH:MM, BUT NOT
+            #       YYYY-MM-DDTHH:MM:SS+HHMM (default from --output=short-iso-precise
             time_ts = datetime.fromisoformat(time_str)
             time_ns = int(datetime.timestamp(time_ts) * 1e9)
             line = line[first_space:].strip()[:128]

--- a/software/python-package/shepherd_sheep/h5_monitor_phc2sys.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_phc2sys.py
@@ -91,7 +91,11 @@ class PHC2SYSMonitor(Monitor):
                     int(words[i_start + 4]),
                     int(words[i_start + 6]),
                 ]
-                time_ts = datetime.fromisoformat(words[0])
+                time_str = words[0][:-2] + ":" + words[0][-2:]
+                # TODO: workaround for py < 3.11, .fromisoformat() can handle
+                #       YYYY-MM-DDTHH:MM:SS+HH:MM, BUT NOT
+                #       YYYY-MM-DDTHH:MM:SS+HHMM (default from --output=short-iso-precise
+                time_ts = datetime.fromisoformat(time_str)
                 time_ns = int(datetime.timestamp(time_ts) * 1e9)
             except ValueError:
                 continue

--- a/software/python-package/shepherd_sheep/h5_monitor_ptp.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_ptp.py
@@ -90,7 +90,11 @@ class PTPMonitor(Monitor):
                     int(words[i_start + 4]),
                     int(words[i_start + 7]),
                 ]
-                time_ts = datetime.fromisoformat(words[0])
+                time_str = words[0][:-2] + ":" + words[0][-2:]
+                # TODO: workaround for py < 3.11, .fromisoformat() can handle
+                #       YYYY-MM-DDTHH:MM:SS+HH:MM, BUT NOT
+                #       YYYY-MM-DDTHH:MM:SS+HHMM (default from --output=short-iso-precise
+                time_ts = datetime.fromisoformat(time_str)
                 time_ns = int(datetime.timestamp(time_ts) * 1e9)
             except ValueError:
                 continue


### PR DESCRIPTION
sheep failed to log dmesg, ptp, phc2sys and ntp on older py versions.