### PR TITLE
v0.9.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.2
+current_version = 0.9.3
 commit = False
 tag = False
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.13'
+    rev: 'v0.12.0'
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,6 +18,7 @@ ignore = [
     "D404", "D405", "D406", "D407", "D408", "D409",  # conflicts with PEP257-convention (B)
     "D410", "D411", "D413", "D415", "D416", "D417",  # conflicts with PEP257-convention (C)
     "EM101", "TRY003",  # xpt & strings
+    "PLC0415",  # not only import at top-level
     # TODO: for releasing now - do add documentation later
     "D",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - sheep - emu / hrv
   - allow custom samplerate for power-tracing - data will be binned by mean() the samples
   - allow to record only power (U * I)
+  - **Caution**: resampling IV-Samples with that method might lead to faulty results for target-voltages that are not constant (Sum(U * I) != Sum(U) * Sum(I))
 
 ## 0.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # History of Changes
 
+## 0.9.3
+
+- herd - bugfix for sending Task to sheep
+  - always convert to file now
+  - ByteIO and StringIO seems broken on some py versions - stream gets corrupted
+- sheep - emu / hrv
+  - allow custom samplerate for power-tracing - data will be binned by mean() the samples
+  - allow to record only power (U * I)
+
 ## 0.9.2
 
 - update all links and referenced for moving repos to `nes-lab`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.realpath("../software/shepherd-webapi"))
 project = "SHEPHERD"
 project_copyright = "2019-2025, Networked Embedded Systems Lab, TU Darmstadt & TU Dresden"
 author = "Ingmar Splitt, Kai Geissdoerfer"
-release = "0.9.2"
+release = "0.9.3"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -123,7 +123,7 @@ Use `bump2version` to update the version number across the repository:
 ```shell
 pipenv shell
 pre-commit run --all-files
-bump2version --allow-dirty --new-version 0.9.2 patch
+bump2version --allow-dirty --new-version 0.9.3 patch
 # version-format: major.minor.patch
 ```
 

--- a/software/debug_analyze_time_sync/config_emulation.yaml
+++ b/software/debug_analyze_time_sync/config_emulation.yaml
@@ -30,9 +30,7 @@ parameters:
   gpio_tracing: null
 #    uart_decode: true
 #    uart_baudrate: 115200
-  power_tracing:
-    discard_voltage: false
-    discard_current: false
+  power_tracing: {}
   sys_logging:
     dmesg: false
     ptp: false

--- a/software/debug_analyze_time_sync/sync_analysis/__init__.py
+++ b/software/debug_analyze_time_sync/sync_analysis/__init__.py
@@ -2,7 +2,7 @@ from .logger import log
 from .logic_trace import LogicTrace
 from .logic_traces import LogicTraces
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "LogicTrace",

--- a/software/debug_analyze_time_sync/sync_analysis/logic_traces.py
+++ b/software/debug_analyze_time_sync/sync_analysis/logic_traces.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from . import log
+from .logger import log
 from .logic_trace import LogicTrace
 
 

--- a/software/firmware/pru0-module-py/shepherd_pru/__init__.py
+++ b/software/firmware/pru0-module-py/shepherd_pru/__init__.py
@@ -6,7 +6,7 @@ from .pru_harvester_simulation import simulate_harvester
 from .pru_source_model import PruSourceModel
 from .pru_source_simulation import simulate_source
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "PruConverterModel",

--- a/software/kernel-module/src/module_base.c
+++ b/software/kernel-module/src/module_base.c
@@ -198,5 +198,5 @@ module_platform_driver(shepherd_driver);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Kai Geissdoerfer");
 MODULE_DESCRIPTION("Shepherd kernel module for time synchronization and data exchange to PRUs");
-MODULE_VERSION("0.9.2");
+MODULE_VERSION("0.9.3");
 // MODULE_ALIAS("rpmsg:rpmsg-shprd"); // TODO: is this still needed?

--- a/software/pps-gmtimer/src/pps-gmtimer.c
+++ b/software/pps-gmtimer/src/pps-gmtimer.c
@@ -42,7 +42,7 @@
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Dan Drown");
 MODULE_DESCRIPTION("PPS Client Driver using OMAP Timer hardware");
-MODULE_VERSION("0.9.2");
+MODULE_VERSION("0.9.3");
 
 struct pps_gmtimer_platform_data
 {

--- a/software/python-package/example_config_emulation.yaml
+++ b/software/python-package/example_config_emulation.yaml
@@ -30,7 +30,5 @@ parameters:
   uart_logging:
     baudrate: 115200
   gpio_tracing: {}  # trick for unchanged default
-  power_tracing:
-    discard_voltage: false
-    discard_current: false
+  power_tracing: {}
   verbose: 2 # serious performance impact for value > 3

--- a/software/python-package/pyproject.toml
+++ b/software/python-package/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 requires-python = ">= 3.10"
 dependencies = [
-    "shepherd-core[elf,inventory]>=2025.06.3",  # limit due to newest features
+    "shepherd-core[elf,inventory]>=2025.06.4",  # limit due to newest features
     "click",
     "numpy",
     "python-periphery<2.0.0", # v2 has no persistence anymore
@@ -60,6 +60,7 @@ test = [
     "pytest-timeout",
     "pytest-click",
     "coverage",
+    "flaky",  # TODO: integrate
 ]
 doc = ["dbus-python"]
 # TODO doc should trigger on

--- a/software/python-package/shepherd_launcher/__init__.py
+++ b/software/python-package/shepherd_launcher/__init__.py
@@ -15,7 +15,7 @@ from types import TracebackType
 
 from typing_extensions import Self
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 # Top-Level Package-logger
 log = logging.getLogger("ShpLauncher")

--- a/software/python-package/shepherd_sheep/__init__.py
+++ b/software/python-package/shepherd_sheep/__init__.py
@@ -40,7 +40,7 @@ from .sysfs_interface import check_sys_access
 from .sysfs_interface import flatten_list
 from .target_io import TargetIO
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "EEPROM",

--- a/software/python-package/shepherd_sheep/commons.py
+++ b/software/python-package/shepherd_sheep/commons.py
@@ -78,7 +78,7 @@ pru_errors: dict[int, str] = {
 }
 
 # fmt: off
-# ruff: noqa: E241, E501
+# ruff: noqa: E501
 GPIO_LOG_BIT_POSITIONS = {
     0: {"pru_reg": "r31_00", "name": "tgt_gpio0",   "bb_pin": "P8_45", "sys_pin": "P8_14", "sys_reg": "26"},
     1: {"pru_reg": "r31_01", "name": "tgt_gpio1",   "bb_pin": "P8_46", "sys_pin": "P8_17", "sys_reg": "27"},

--- a/software/python-package/shepherd_sheep/h5_recorder_power.py
+++ b/software/python-package/shepherd_sheep/h5_recorder_power.py
@@ -1,0 +1,110 @@
+from types import TracebackType
+
+import h5py
+import numpy as np
+from shepherd_core import CalibrationEmulator as CalEmu
+from shepherd_core import CalibrationSeries as CalSeries
+from shepherd_core import Compression
+from shepherd_core.config import ConfigDefault
+
+from . import log
+from .commons import SAMPLE_INTERVAL_NS
+from .h5_monitor_abc import Monitor
+from .shared_mem_iv_input import IVTrace
+from .shared_mem_iv_output import SharedMemIVOutput
+
+
+class PowerRecorder(Monitor):
+    RATES_SUPPORTED = (10, 100, 1_000, 100_000)
+
+    def __init__(
+        self,
+        data_rate: int,
+        cal_data: CalSeries | CalEmu,
+        target: h5py.Group,
+        compression: Compression | None = Compression.default,
+    ) -> None:
+        super().__init__(
+            target, compression, poll_interval=0, increment=SharedMemIVOutput.N_SAMPLES_PER_CHUNK
+        )
+
+        if data_rate not in self.RATES_SUPPORTED:
+            raise ValueError(
+                "Data-rate for Power must be in [Hz, Samples-per-second]: %s",
+                self.RATES_SUPPORTED,
+            )
+        self.data_rate = data_rate
+        self.reduction_factor: int = ConfigDefault.SAMPLERATE_SPS // self.data_rate
+        self.reduce: bool = self.data_rate != ConfigDefault.SAMPLERATE_SPS
+
+        if isinstance(cal_data, CalEmu):
+            self.cal_data = CalSeries.from_cal(cal_data)
+        elif isinstance(cal_data, CalSeries):
+            self.cal_data = cal_data
+        else:
+            raise ValueError("calibration must be CalibrationSeries or CalibrationEmulator")
+
+        self.gain: float = 1e-9  # nW
+        self.data.create_dataset(
+            name="value",
+            shape=(self.increment,),
+            dtype="u4",
+            maxshape=(None,),
+            chunks=(self.increment,),
+            compression=compression,
+        )
+        self.data["value"].attrs["unit"] = "W"
+        self.data["value"].attrs["description"] = "Power [W] = value/nW * gain + (offset)"
+        self.data["value"].attrs["gain"] = self.gain
+        self.data["value"].attrs["offset"] = 0
+
+    def __exit__(
+        self,
+        typ: type[BaseException] | None = None,
+        exc: BaseException | None = None,
+        tb: TracebackType | None = None,
+        extra_arg: int = 0,
+    ) -> None:
+        self.data["value"].resize((self.position,))
+        super().__exit__()
+
+    def write(self, data: IVTrace) -> None:
+        len_add = len(data)
+        if len_add < 1:
+            return
+        if self.data_rate != ConfigDefault.SAMPLERATE_SPS and len_add % self.data_rate != 0:
+            log.warning("Power-Tracer got odd size - some samples will be discarded")
+        power = (
+            self.cal_data.voltage.raw_to_si(data.voltage[:len_add])
+            * self.cal_data.current.raw_to_si(data.current[:len_add])
+            / self.gain
+        )
+        if self.reduce:
+            len_add = len_add // self.reduction_factor
+            power = np.reshape(power, (len_add, self.reduction_factor)).mean(axis=1)
+        power = power.astype("u4")
+        if isinstance(data.timestamp_ns, int):
+            # This is currently not used
+            _ts = (
+                self.reduction_factor * SAMPLE_INTERVAL_NS * np.arange(len_add).astype("u8")
+                + data.timestamp_ns
+            )
+        elif isinstance(data.timestamp_ns, np.ndarray):
+            # benchmarked slices: [:] is as fast as [::1] on BBB
+            _ts = data.timestamp_ns[: len(data) : self.reduction_factor]
+        else:
+            raise ValueError("timestamp_ns must be int or np.ndarray")
+
+        pos_end = self.position + len_add
+        data_length = self.data["time"].shape[0]
+
+        if pos_end >= data_length:
+            data_length += max(self.increment, pos_end - data_length)
+            self.data["time"].resize((data_length,))
+            self.data["value"].resize((data_length,))
+        self.data["time"][self.position : pos_end] = _ts
+        self.data["value"][self.position : pos_end] = power
+        self.position = pos_end
+
+    def thread_fn(self) -> None:
+        raise NotImplementedError

--- a/software/python-package/shepherd_sheep/h5_recorder_power.py
+++ b/software/python-package/shepherd_sheep/h5_recorder_power.py
@@ -5,11 +5,10 @@ import numpy as np
 from shepherd_core import CalibrationEmulator as CalEmu
 from shepherd_core import CalibrationSeries as CalSeries
 from shepherd_core import Compression
-from shepherd_core.config import ConfigDefault
 
-from . import log
 from .commons import SAMPLE_INTERVAL_NS
 from .h5_monitor_abc import Monitor
+from .logger import log
 from .shared_mem_iv_input import IVTrace
 from .shared_mem_iv_output import SharedMemIVOutput
 
@@ -27,15 +26,15 @@ class PowerRecorder(Monitor):
         super().__init__(
             target, compression, poll_interval=0, increment=SharedMemIVOutput.N_SAMPLES_PER_CHUNK
         )
-
+        self.samplerate_sps: int = 10**9 // SAMPLE_INTERVAL_NS
         if data_rate not in self.RATES_SUPPORTED:
             raise ValueError(
                 "Data-rate for Power must be in [Hz, Samples-per-second]: %s",
                 self.RATES_SUPPORTED,
             )
         self.data_rate = data_rate
-        self.reduction_factor: int = ConfigDefault.SAMPLERATE_SPS // self.data_rate
-        self.reduce: bool = self.data_rate != ConfigDefault.SAMPLERATE_SPS
+        self.reduction_factor: int = self.samplerate_sps // self.data_rate
+        self.reduce: bool = self.data_rate != self.samplerate_sps
 
         if isinstance(cal_data, CalEmu):
             self.cal_data = CalSeries.from_cal(cal_data)
@@ -72,7 +71,7 @@ class PowerRecorder(Monitor):
         len_add = len(data)
         if len_add < 1:
             return
-        if self.data_rate != ConfigDefault.SAMPLERATE_SPS and len_add % self.data_rate != 0:
+        if self.reduce and len_add % self.data_rate != 0:
             log.warning("Power-Tracer got odd size - some samples will be discarded")
         power = (
             self.cal_data.voltage.raw_to_si(data.voltage[:len_add])
@@ -82,7 +81,7 @@ class PowerRecorder(Monitor):
         if self.reduce:
             len_add = len_add // self.reduction_factor
             power = np.reshape(power, (len_add, self.reduction_factor)).mean(axis=1)
-        power = power.astype("u4")
+        power = np.clip(power, 0, 2**32).astype("u4")
         if isinstance(data.timestamp_ns, int):
             # This is currently not used
             _ts = (

--- a/software/python-package/shepherd_sheep/h5_recorder_power.py
+++ b/software/python-package/shepherd_sheep/h5_recorder_power.py
@@ -42,7 +42,7 @@ class PowerRecorder(Monitor):
         elif isinstance(cal_data, CalSeries):
             self.cal_data = cal_data
         else:
-            raise ValueError("calibration must be CalibrationSeries or CalibrationEmulator")
+            raise TypeError("calibration must be CalibrationSeries or CalibrationEmulator")
 
         self.gain: float = 1e-9  # nW
         self.data.create_dataset(
@@ -93,7 +93,7 @@ class PowerRecorder(Monitor):
             # benchmarked slices: [:] is as fast as [::1] on BBB
             _ts = data.timestamp_ns[: len(data) : self.reduction_factor]
         else:
-            raise ValueError("timestamp_ns must be int or np.ndarray")
+            raise TypeError("timestamp_ns must be int or np.ndarray")
 
         pos_end = self.position + len_add
         data_length = self.data["time"].shape[0]

--- a/software/python-package/shepherd_sheep/h5_writer.py
+++ b/software/python-package/shepherd_sheep/h5_writer.py
@@ -99,6 +99,7 @@ class Writer(CoreWriter):
             verbose=verbose,
         )
         self.only_power = only_power
+
         self.buffer_timeseries = self.sample_interval_ns * np.arange(
             self.CHUNK_SAMPLES_N,
         ).astype("u8")

--- a/software/python-package/shepherd_sheep/h5_writer.py
+++ b/software/python-package/shepherd_sheep/h5_writer.py
@@ -41,6 +41,7 @@ from .h5_recorder_pru import PruRecorder
 from .logger import log
 from .shared_mem_gpio_output import GPIOTrace
 from .shared_mem_iv_input import IVTrace
+from .shared_mem_iv_output import SharedMemIVOutput
 from .shared_mem_util_output import UtilTrace
 
 
@@ -104,10 +105,8 @@ class Writer(CoreWriter):
         self.only_power = only_power
 
         self.buffer_timeseries = self.sample_interval_ns * np.arange(
-            self.CHUNK_SAMPLES_N,
+            SharedMemIVOutput.N_SAMPLES_PER_CHUNK,
         ).astype("u8")
-        # TODO: keep this optimization, but it is also currently not used (and has wrong size)
-        #       length should be SharedMemIVOutput.N_SAMPLES_PER_CHUNK
 
         self.grp_data: h5py.Group = self.h5file["data"]
 
@@ -229,13 +228,10 @@ class Writer(CoreWriter):
             self.grp_data["voltage"][self.data_pos : data_end_pos] = data.voltage
             self.grp_data["current"][self.data_pos : data_end_pos] = data.current
             if isinstance(data.timestamp_ns, int):
-                # NOTE: this mode is currently not used,
-                #       BUG - the buffer_timeseries has wrong length!
-                #             should be SharedMemIVOutput.N_SAMPLES_PER_CHUNK
                 self.grp_data["time"][self.data_pos : data_end_pos] = (
                     self.buffer_timeseries + data.timestamp_ns
-                )
-                raise NotImplementedError
+                )[:len_add]
+
             if isinstance(data.timestamp_ns, np.ndarray):
                 self.grp_data["time"][self.data_pos : data_end_pos] = data.timestamp_ns
             self.data_pos = data_end_pos

--- a/software/python-package/shepherd_sheep/h5_writer.py
+++ b/software/python-package/shepherd_sheep/h5_writer.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 
 from . import commons
 from .h5_monitor_ntp import NTPMonitor
+from .h5_recorder_power import PowerRecorder
 
 if TYPE_CHECKING:
     import h5py
@@ -54,6 +55,8 @@ class Writer(CoreWriter):
         force_overwrite (bool): Overwrite existing file with the same name
     """
 
+    RATES_SUPPORTED = (10, 100, 1_000, 100_000)
+
     def __init__(
         self,
         file_path: Path,
@@ -62,13 +65,26 @@ class Writer(CoreWriter):
         window_samples: int | None = None,
         cal_data: CalSeries | CalEmu | CalHrv | None = None,
         compression: Compression = Compression.default,
+        sample_rate: int | None = None,
         *,
         modify_existing: bool = False,
         force_overwrite: bool = False,
+        only_power: bool = False,
         verbose: bool | None = True,
     ) -> None:
         # hopefully overwrite defaults from Reader
         self.samplerate_sps: int = 10**9 // commons.SAMPLE_INTERVAL_NS
+        self.reduce: bool = False
+        self.reduction_factor: int = 1
+        if isinstance(sample_rate, int):
+            if sample_rate not in self.RATES_SUPPORTED:
+                raise ValueError(
+                    "Data-rate for Power must be in [Hz, Samples-per-second]: %s",
+                    self.RATES_SUPPORTED,
+                )
+            self.reduce: bool = sample_rate != self.samplerate_sps
+            self.reduction_factor: int = self.samplerate_sps // sample_rate
+            self.samplerate_sps = sample_rate
 
         # TODO: derive verbose-state
         super().__init__(
@@ -82,11 +98,12 @@ class Writer(CoreWriter):
             force_overwrite=force_overwrite,
             verbose=verbose,
         )
-
+        self.only_power = only_power
         self.buffer_timeseries = self.sample_interval_ns * np.arange(
             self.CHUNK_SAMPLES_N,
         ).astype("u8")
-        # TODO: keep this optimization
+        # TODO: keep this optimization, but it is also currently not used (and has wrong size)
+        #       length should be SharedMemIVOutput.N_SAMPLES_PER_CHUNK
 
         self.grp_data: h5py.Group = self.h5file["data"]
 
@@ -123,6 +140,14 @@ class Writer(CoreWriter):
         # prepare recorders
         self.rec_gpio = GpioRecorder(self.gpio_grp, compression=self._compression)
         self.rec_pru = PruRecorder(self.pru_util_grp, compression=self._compression)
+        if self.only_power:
+            self.power_grp = self.h5file.create_group("power")
+            self.rec_power = PowerRecorder(
+                data_rate=self.samplerate_sps,
+                cal_data=self._cal,
+                target=self.power_grp,
+                compression=self._compression,
+            )
 
         # targets for logging-monitor # TODO: redesign? all should be kept in data_0
         self.sheep_grp = self.h5file.create_group("sheep")
@@ -163,9 +188,30 @@ class Writer(CoreWriter):
             data: buffer-segment containing IV data
         """
         # First, we have to resize the corresponding datasets
-        data_length_new = len(data)
-        if data_length_new > 0:
-            data_end_pos = self.data_pos + data_length_new
+        if self.only_power:
+            self.rec_power.write(data)
+            return
+        if self.reduce:  # aka resampling via binning
+            len_add = len(data)
+            data.voltage = (
+                np.reshape(data.voltage[:len_add], (len_add, self.reduction_factor))
+                .mean(axis=1)
+                .astype("u4")
+            )
+            data.current = (
+                np.reshape(data.current[:len_add], (len_add, self.reduction_factor))
+                .mean(axis=1)
+                .astype("u4")
+            )
+            if isinstance(data.timestamp_ns, np.ndarray):
+                # benchmarked slices: [:] is as fast as [::1] on BBB
+                data.timestamp_ns = data.timestamp_ns[: len_add : self.reduction_factor]
+            else:
+                raise ValueError("timestamp_ns must be np.ndarray")
+
+        len_add = len(data)
+        if len_add > 0:
+            data_end_pos = self.data_pos + len_add
             data_length_h5 = self.grp_data["voltage"].shape[0]
             if data_end_pos >= data_length_h5:
                 data_length_h5 += self.data_inc
@@ -176,10 +222,14 @@ class Writer(CoreWriter):
             self.grp_data["voltage"][self.data_pos : data_end_pos] = data.voltage
             self.grp_data["current"][self.data_pos : data_end_pos] = data.current
             if isinstance(data.timestamp_ns, int):
+                # NOTE: this mode is currently not used,
+                #       BUG - the buffer_timeseries has wrong length!
+                #             should be SharedMemIVOutput.N_SAMPLES_PER_CHUNK
                 self.grp_data["time"][self.data_pos : data_end_pos] = (
                     self.buffer_timeseries + data.timestamp_ns
                 )
-            elif isinstance(data.timestamp_ns, np.ndarray):
+                raise NotImplementedError
+            if isinstance(data.timestamp_ns, np.ndarray):
                 self.grp_data["time"][self.data_pos : data_end_pos] = data.timestamp_ns
             self.data_pos = data_end_pos
 

--- a/software/python-package/shepherd_sheep/h5_writer.py
+++ b/software/python-package/shepherd_sheep/h5_writer.py
@@ -38,6 +38,7 @@ from .h5_monitor_sysutil import SysUtilMonitor
 from .h5_monitor_uart import UARTMonitor
 from .h5_recorder_gpio import GpioRecorder
 from .h5_recorder_pru import PruRecorder
+from .logger import log
 from .shared_mem_gpio_output import GPIOTrace
 from .shared_mem_iv_input import IVTrace
 from .shared_mem_util_output import UtilTrace
@@ -85,6 +86,8 @@ class Writer(CoreWriter):
             self.reduce: bool = sample_rate != self.samplerate_sps
             self.reduction_factor: int = self.samplerate_sps // sample_rate
             self.samplerate_sps = sample_rate
+        if self.reduce:
+            log.info("Activated custom sample-rate: %d", self.samplerate_sps)
 
         # TODO: derive verbose-state
         super().__init__(
@@ -175,6 +178,8 @@ class Writer(CoreWriter):
         # end recorders
         self.rec_gpio.__exit__()
         self.rec_pru.__exit__()
+        if hasattr(self, "rec_power"):
+            self.rec_power.__exit__()
 
         # end monitors
         for monitor in self.monitors:
@@ -194,13 +199,14 @@ class Writer(CoreWriter):
             return
         if self.reduce:  # aka resampling via binning
             len_add = len(data)
+            len_new = len_add // self.reduction_factor
             data.voltage = (
-                np.reshape(data.voltage[:len_add], (len_add, self.reduction_factor))
+                np.reshape(data.voltage[:len_add], (len_new, self.reduction_factor))
                 .mean(axis=1)
                 .astype("u4")
             )
             data.current = (
-                np.reshape(data.current[:len_add], (len_add, self.reduction_factor))
+                np.reshape(data.current[:len_add], (len_new, self.reduction_factor))
                 .mean(axis=1)
                 .astype("u4")
             )

--- a/software/python-package/shepherd_sheep/shared_mem_iv_output.py
+++ b/software/python-package/shepherd_sheep/shared_mem_iv_output.py
@@ -161,9 +161,7 @@ class SharedMemIVOutput:
         avail_length = self.get_size_available()
 
         if avail_length < self.N_SAMPLES_PER_CHUNK:
-            # nothing to do
-            # TODO: abandon segment-idea, read up to pru-index, add force to go below segment_size
-            return None
+            return None  # nothing to do
 
         if self.fill_level > 0.8:
             log.warning(

--- a/software/python-package/shepherd_sheep/shepherd_emulator.py
+++ b/software/python-package/shepherd_sheep/shepherd_emulator.py
@@ -132,6 +132,8 @@ class ShepherdEmulator(ShepherdIO):
                 mode=self.component,  # is a cleaned up mode
                 datatype=EnergyDType.ivsample,
                 cal_data=self.cal_emu,
+                sample_rate=cfg.power_tracing.sample_rate,
+                only_power=cfg.power_tracing.only_power,
                 compression=cfg.output_compression,
                 verbose=get_verbosity(),
             )
@@ -346,5 +348,5 @@ class ShepherdEmulator(ShepherdIO):
                 log.error(
                     "Recorder missed %.3f s IVTrace after start", file_start - self.start_time
                 )
-            if file_end < ts_end - 1e-3:
-                log.error("Recorder missed %.3f s IVTrace before end", ts_end - file_end)
+            if file_end < ts_end - max(1e-3, 2.0 / self.writer.samplerate_sps):
+                log.error("Recorder missed ~ %.3f s IVTrace before end", ts_end - file_end)

--- a/software/python-package/shepherd_sheep/shepherd_emulator.py
+++ b/software/python-package/shepherd_sheep/shepherd_emulator.py
@@ -132,7 +132,7 @@ class ShepherdEmulator(ShepherdIO):
                 mode=self.component,  # is a cleaned up mode
                 datatype=EnergyDType.ivsample,
                 cal_data=self.cal_emu,
-                sample_rate=cfg.power_tracing.sample_rate,
+                sample_rate=cfg.power_tracing.samplerate,
                 only_power=cfg.power_tracing.only_power,
                 compression=cfg.output_compression,
                 verbose=get_verbosity(),

--- a/software/python-package/shepherd_sheep/shepherd_harvester.py
+++ b/software/python-package/shepherd_sheep/shepherd_harvester.py
@@ -75,6 +75,8 @@ class ShepherdHarvester(ShepherdIO):
             datatype=cfg.virtual_harvester.get_datatype(),
             window_samples=cfg.virtual_harvester.calc_window_size(for_emu=True),
             cal_data=self.cal_hrv,
+            sample_rate=cfg.power_tracing.sample_rate,  # TODO: should raise for ivcurves
+            only_power=cfg.power_tracing.only_power,
             compression=cfg.output_compression,
             force_overwrite=cfg.force_overwrite,
             verbose=get_verbosity(),
@@ -190,5 +192,5 @@ class ShepherdHarvester(ShepherdIO):
         file_end = self.writer.ds_time[self.writer.data_pos - 1] * gain
         if file_start > self.start_time:
             log.error("Recorder missed %.3f s IVTrace after start", file_start - self.start_time)
-        if file_end < ts_end - 1e-3:
-            log.error("Recorder missed %.3f s IVTrace before end", file_end - ts_end)
+        if file_end < ts_end - max(1e-3, 2.0 / self.writer.samplerate_sps):
+            log.error("Recorder missed ~ %.3f s IVTrace before end", file_end - ts_end)

--- a/software/python-package/shepherd_sheep/shepherd_harvester.py
+++ b/software/python-package/shepherd_sheep/shepherd_harvester.py
@@ -75,7 +75,7 @@ class ShepherdHarvester(ShepherdIO):
             datatype=cfg.virtual_harvester.get_datatype(),
             window_samples=cfg.virtual_harvester.calc_window_size(for_emu=True),
             cal_data=self.cal_hrv,
-            sample_rate=cfg.power_tracing.sample_rate,  # TODO: should raise for ivcurves
+            sample_rate=cfg.power_tracing.samplerate,  # TODO: should raise for ivcurves
             only_power=cfg.power_tracing.only_power,
             compression=cfg.output_compression,
             force_overwrite=cfg.force_overwrite,

--- a/software/python-package/shepherd_sheep/shepherd_io.py
+++ b/software/python-package/shepherd_sheep/shepherd_io.py
@@ -348,7 +348,7 @@ class ShepherdIO:
             time.sleep(0.5)  # time to stabilize voltage-drop
 
     @staticmethod
-    def convert_target_port_to_bool(target: TargetPort | str | bool | None) -> bool:
+    def convert_target_port_to_bool(target: TargetPort | str | bool | None) -> bool:  # noqa: FBT001
         if target is None:
             return True
         if isinstance(target, str):
@@ -362,7 +362,7 @@ class ShepherdIO:
 
     def select_port_for_power_tracking(
         self,
-        target: TargetPort | bool | None,
+        target: TargetPort | bool | None,  # noqa: FBT001
     ) -> None:
         """
         choose which targets (A or B) gets the supply with current-monitor,
@@ -387,7 +387,7 @@ class ShepherdIO:
 
     def select_port_for_io_interface(
         self,
-        target: TargetPort | bool | None,
+        target: TargetPort | bool | None,  # noqa: FBT001
     ) -> None:
         """Choose which targets (A or B) gets the io-connection (serial, swd, gpio) from beaglebone,
 

--- a/software/python-package/shepherd_sheep/sysfs_interface.py
+++ b/software/python-package/shepherd_sheep/sysfs_interface.py
@@ -58,7 +58,7 @@ def flatten_list(dl: list) -> list:
 def load_kernel_module() -> None:
     _try = 6
     while _try > 0:
-        ret = subprocess.run(  # noqa: S603
+        ret = subprocess.run(
             ["/usr/sbin/modprobe", "-a", "shepherd"],
             timeout=60,
             check=False,
@@ -75,7 +75,7 @@ def load_kernel_module() -> None:
 def remove_kernel_module(name: str = "shepherd") -> None:
     _try = 6
     while _try > 0:
-        ret = subprocess.run(  # noqa: S603
+        ret = subprocess.run(
             ["/usr/sbin/modprobe", "-rf", "shepherd"],
             timeout=60,
             capture_output=True,
@@ -99,13 +99,13 @@ def reload_kernel_module() -> None:
 
 
 def disable_ntp() -> None:
-    ret = subprocess.run(  # noqa: S603
+    ret = subprocess.run(
         ["/usr/bin/systemctl", "is-active", "--quiet", "systemd-timesyncd.service"],
         timeout=20,
         check=False,
     ).returncode
     if ret == 0:
-        subprocess.run(  # noqa: S603
+        subprocess.run(
             ["/usr/bin/systemctl", "stop", "systemd-timesyncd.service"],
             timeout=20,
             check=False,

--- a/software/python-package/shepherd_watchdog/__init__.py
+++ b/software/python-package/shepherd_watchdog/__init__.py
@@ -10,7 +10,7 @@ from types import TracebackType
 
 from typing_extensions import Self
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 # Top-Level Package-logger
 log = logging.getLogger("ShpWatchdog")

--- a/software/python-package/tests/_test_config_emulation.yaml
+++ b/software/python-package/tests/_test_config_emulation.yaml
@@ -15,7 +15,5 @@ parameters:
   voltage_aux: 3.3
   gpio_tracing:
     uart_baudrate: 9600
-  power_tracing:
-    discard_voltage: false
-    discard_current: false
+  power_tracing: {}
   verbose: 2

--- a/software/python-package/tests/test_cli_run_task.py
+++ b/software/python-package/tests/test_cli_run_task.py
@@ -296,7 +296,7 @@ def test_cli_emulate_parameters_long(
         io_port="B",
         pwr_port="B",
         gpio_tracing=GpioTracing(uart_baudrate=9600),
-        power_tracing=PowerTracing(discard_current=False, discard_voltage=False),
+        power_tracing=PowerTracing(),
         verbose=3,
     ).to_file(tmp_yaml)
 

--- a/software/python-package/tests/test_cli_run_task.py
+++ b/software/python-package/tests/test_cli_run_task.py
@@ -140,6 +140,7 @@ def test_cli_harvest_preconfigured(
     path_here: Path,
 ) -> None:
     file_path = path_here / "_test_config_harvest.yaml"
+    assert file_path.exists()
     res = cli_runner.invoke(cli, ["run", file_path.as_posix()])
     assert res.exit_code == 0
 
@@ -152,6 +153,7 @@ def test_cli_harvest_preconf_etc_shp_examples(
     path_here: Path,
 ) -> None:
     file_path = path_here.parent / "example_config_harvest.yaml"
+    assert file_path.exists()
     res = cli_runner.invoke(cli, ["run", f"{file_path}"])
     assert res.exit_code == 0
 

--- a/software/shepherd-calibration/shepherd_cal/__init__.py
+++ b/software/shepherd-calibration/shepherd_cal/__init__.py
@@ -6,7 +6,7 @@ from .profile_analyzer import analyze_directory
 from .profile_cape import ProfileCape
 from .profiler import Profiler
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "Calibrator",

--- a/software/shepherd-calibration/shepherd_cal/profiler.py
+++ b/software/shepherd-calibration/shepherd_cal/profiler.py
@@ -21,8 +21,6 @@ from shepherd_core.data_models.testbed.cape import TargetPort
 from .calibrator import Calibrator
 from .logger import log
 
-# ruff: noqa: FBT003
-
 INSTR_PROFILE_SHP = """
 ---------------------- Characterize Shepherd-Frontend -----------------------
 - remove targets from target-ports

--- a/software/shepherd-calibration/shepherd_cal/profiler_cli.py
+++ b/software/shepherd-calibration/shepherd_cal/profiler_cli.py
@@ -25,7 +25,7 @@ from .profile_analyzer import analyze_directory
 from .profiler import INSTR_PROFILE_SHP
 from .profiler import Profiler
 
-# ruff: noqa: FBT001, FBT003
+# ruff: noqa: FBT001
 
 cli_pro = typer.Typer(
     name="profile",

--- a/software/shepherd-herd/pyproject.toml
+++ b/software/shepherd-herd/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "shepherd-core[elf,inventory]>=2025.06.3",  # limit due to newest features
+    "shepherd-core[elf,inventory]>=2025.06.4",  # limit due to newest features
     "click",
     "numpy",
     "fabric",

--- a/software/shepherd-herd/shepherd_herd/__init__.py
+++ b/software/shepherd-herd/shepherd_herd/__init__.py
@@ -12,7 +12,7 @@ from .logger import activate_verbosity
 from .logger import get_verbosity
 from .logger import log
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "Herd",

--- a/software/shepherd-herd/shepherd_herd/herd.py
+++ b/software/shepherd-herd/shepherd_herd/herd.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from pathlib import Path
 from pathlib import PurePath
 from pathlib import PurePosixPath
+from tempfile import TemporaryDirectory
 from types import TracebackType
 from typing import Any
 
@@ -343,6 +344,7 @@ class Herd:
         force_overwrite: bool = False,
     ) -> None:
         if isinstance(src, BytesIO):
+            log.warning("BytesIO is buggy on some py-versions (only partial copy) -> use paths")
             src_path = src
         else:
             src_path = Path(src).absolute()
@@ -534,41 +536,48 @@ class Herd:
         """
         if remote_path.suffix.lower() != ".pickle":
             raise NameError("Remote path must point to '.pickle'")
-        if isinstance(task, ShpModel):  # Model gets pickled
-            task_dict = task.model_dump(exclude_unset=True)
-            task_wrap = Wrapper(
-                datatype=type(task).__name__,
-                created=datetime.now(tz=local_tz()),
-                parameters=task_dict,
+
+        with TemporaryDirectory() as temp_dir:
+            if isinstance(task, ShpModel):  # Model gets pickled to file
+                task_dict = task.model_dump(exclude_unset=True)
+                task_wrap = Wrapper(
+                    datatype=type(task).__name__,
+                    created=datetime.now(tz=local_tz()),
+                    parameters=task_dict,
+                )
+                wrap_dict = path_to_str(task_wrap.model_dump(exclude_unset=True))
+                task = Path(temp_dir) / "herd.pickle"
+                # NOTE: preferred way is ByteIO/StringIO, but it is highly buggy
+                with task.open("wb") as fd:
+                    pickle.dump(wrap_dict, fd)
+
+            elif isinstance(task, Path):  # file gets pickled if it is YAML (speedup sheep)
+                if not task.is_file() or not task.exists():
+                    raise FileNotFoundError("Task-Path must be an existing file")
+                if task.is_file():
+                    task_wrap = prepare_task(task)  # also functions as test
+                    if task.suffix.lower() == ".yaml":  # repickle to file
+                        wrap_dict = path_to_str(task_wrap.model_dump(exclude_unset=True))
+                        task = Path(temp_dir) / "herd.pickle"
+                        with task.open("wb") as fd:
+                            pickle.dump(wrap_dict, fd)
+            else:
+                raise TypeError("Task must either be model or path to a model")
+
+            if self.check_status(warn=True):
+                raise RuntimeError("Shepherd still active!")
+            if not isinstance(remote_path, PurePath):
+                remote_path = PurePosixPath(remote_path)
+
+            log.info(
+                "Rolling out the config to '%s'",
+                remote_path.as_posix(),
             )
-            wrap_dict = path_to_str(task_wrap.model_dump(exclude_unset=True))
-            task = BytesIO(pickle.dumps(wrap_dict))
-
-        elif isinstance(task, Path):  # file gets pickled if it is YAML (speedup sheep)
-            if not task.is_file() or not task.exists():
-                raise FileNotFoundError("Task-Path must be an existing file")
-            if task.is_file():
-                task_wrap = prepare_task(task)
-                if task.suffix.lower() == ".yaml":
-                    wrap_dict = path_to_str(task_wrap.model_dump(exclude_unset=True))
-                    task = BytesIO(pickle.dumps(wrap_dict))
-        else:
-            raise TypeError("Task must either be model or path to a model")
-
-        if self.check_status(warn=True):
-            raise RuntimeError("Shepherd still active!")
-        if not isinstance(remote_path, PurePath):
-            remote_path = PurePosixPath(remote_path)
-
-        log.info(
-            "Rolling out the config to '%s'",
-            remote_path.as_posix(),
-        )
-        self.put_file(
-            task,
-            remote_path,
-            force_overwrite=True,
-        )
+            self.put_file(
+                task,
+                remote_path,
+                force_overwrite=True,
+            )
 
     @validate_call
     def check_status(self, *, warn: bool = False) -> bool:


### PR DESCRIPTION
- herd - bugfix for sending Task to sheep
  - always convert to file now
  - ByteIO and StringIO seems broken on some py versions - stream gets corrupted
- sheep - emu / hrv
  - allow custom samplerate for power-tracing - data will be binned by mean() the samples
  - allow to record only power (U * I)
  - **Caution**: resampling IV-Samples with that method might lead to faulty results for target-voltages that are not constant (Sum(U * I) != Sum(U) * Sum(I))