### PR TITLE
Dev

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2026.04.2
+current_version = 2026.05.1
 commit = False
 tag = False
 

--- a/.github/workflows/fw_build_gcc.yaml
+++ b/.github/workflows/fw_build_gcc.yaml
@@ -17,10 +17,10 @@ jobs:
         cape_hw_ver: [ "24", "25" ]
     env:
       # as in roles/sheep/vars/main.yml
-      gcc_pru_cc_release: "pru-elf-2025.05.amd64"
+      gcc_pru_cc_release: "pru-elf-2026.05.amd64"
       gcc_pru_support_branch: "linux-4.19-rproc"
       # weblinks
-      link_gcc: "https://github.com/dinuxbg/gnupru/releases/download/2025.05/"
+      link_gcc: "https://github.com/dinuxbg/gnupru/releases/download/2026.05/"
       link_pssp: "https://github.com/dinuxbg/pru-software-support-package.git"
       # env for makefile
       PRU_GCC: "${{ github.workspace }}/pru-elf" # was /pru-elf-2022.05.amd64 before

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-format
       - id: ruff-check
@@ -94,13 +94,13 @@ repos:
         exclude: \.(sch|brd|lbr)$
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
         args: ["--min-severity", "high", "--no-progress", "--fix", "."]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.4
+    rev: v22.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,15 @@ Watchdog
 
 - add network-checker that pings 5 internet-hosts and reboots after all failed
   - feature is turned off per default as it can misbehave in harvesting-scenarios without internet access
-- put config into dedicated file: `/etc/shepherd/watchdog.yaml`
+- config is located @ `/etc/shepherd/watchdog.yaml`
 
 Ansible
 
 - install / build rYAML separately from install sheep
+
+Github
+
+- compile PRU-firmware with GCC 16.1, gnupru 2026.05
 
 ## 2026.04.2
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,6 @@ prek run --all-files
 # additional QA-Tests (currently with open issues)
 ty check
 
-bump2version --allow-dirty --new-version 2026.04.2 patch
+bump2version --allow-dirty --new-version 2026.05.1 patch
 # version-format: YYYY.MM.r
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.realpath("../software/shepherd-webapi"))
 project = "SHEPHERD"
 project_copyright = "2019-2025, Networked Embedded Systems Lab, TU Darmstadt & TU Dresden"
 author = "Ingmar Splitt, Kai Geissdoerfer"
-release = "2026.04.2"
+release = "2026.05.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # uv pip install .
 [project]
 name = "shepherd-main"
-version = "2026.04.2"
+version = "2026.05.1"
 description = "Infrastructure for the Testbed, mainly focused on the Observers "
 readme = "README.md"
 

--- a/software/build_kernel.sh
+++ b/software/build_kernel.sh
@@ -2,12 +2,12 @@
 sudo modprobe -rf 'shepherd'
 sudo modprobe -rf 'shepherd'
 #
-cd /opt/shepherd/software/kernel-module/src/
+cd /opt/shepherd/software/kernel-module/src
 #
 sudo make clean
 make
 sudo make install
 #
-cd /opt/shepherd/software/
+cd /opt/shepherd/software
 #
 sudo modprobe -a 'shepherd'

--- a/software/debug_analyze_time_sync/pyproject.toml
+++ b/software/debug_analyze_time_sync/pyproject.toml
@@ -6,7 +6,7 @@ keywords = ["testbed", "beaglebone", "pru", "logic pro"]
 authors = [{name = "Ingmar Splitt", email = "ingmar.splitt@tu-dresden.de"}]
 maintainers = [{name = "Ingmar Splitt", email = "ingmar.splitt@tu-dresden.de"}]
 
-version = "2026.04.2"
+version = "2026.05.1"
 
 license = "MIT"
 

--- a/software/firmware/pru0-module-py/pyproject.toml
+++ b/software/firmware/pru0-module-py/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
     {name = "Ingmar Splitt", email = "ingmar.splitt@tu-dresden.de"},
 ]
 
-version = "2026.04.2"
+version = "2026.05.1"
 
 license = "MIT"
 

--- a/software/kernel-module/src/module_base.c
+++ b/software/kernel-module/src/module_base.c
@@ -201,5 +201,5 @@ module_platform_driver(shepherd_driver);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Kai Geissdoerfer");
 MODULE_DESCRIPTION("Shepherd kernel module for time synchronization and data exchange to PRUs");
-MODULE_VERSION("2026.04.2");
+MODULE_VERSION("2026.05.1");
 // MODULE_ALIAS("rpmsg:rpmsg-shprd"); // TODO: is this still needed?

--- a/software/pps-gmtimer/src/pps-gmtimer.c
+++ b/software/pps-gmtimer/src/pps-gmtimer.c
@@ -42,7 +42,7 @@
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Dan Drown");
 MODULE_DESCRIPTION("PPS Client Driver using OMAP Timer hardware");
-MODULE_VERSION("2026.04.2");
+MODULE_VERSION("2026.05.1");
 
 struct pps_gmtimer_platform_data
 {

--- a/software/python-package/pyproject.toml
+++ b/software/python-package/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 maintainers = [{name = "Ingmar Splitt", email = "ingmar.splitt@tu-dresden.de"}]
 
-version = "2026.04.2"
+version = "2026.05.1"
 
 license = "MIT"
 

--- a/software/python-package/tests/test_sysfs_interface.py
+++ b/software/python-package/tests/test_sysfs_interface.py
@@ -174,7 +174,7 @@ def test_initial_calibration_settings(cal4sysfs: dict) -> None:
 @pytest.mark.hardware
 @pytest.mark.usefixtures("_shepherd_up")
 def test_initial_harvester_settings() -> None:
-    hrv_list = [0, *list(range(200, 211))]
+    hrv_list = [0, *list(range(200, 212))]
     assert sysfs_interface.read_virtual_harvester_settings() == hrv_list
 
 

--- a/software/readme_compiler_comparison.md
+++ b/software/readme_compiler_comparison.md
@@ -1,0 +1,66 @@
+# Comparison of PRU-compilations
+
+## 2026
+
+- GCC 15.1 action https://github.com/nes-lab/shepherd/actions/runs/26105454588/job/76767871518
+- GCC 16.1 action https://github.com/nes-lab/shepherd/actions/runs/26105845700/job/76769290223
+- CGT v2.3.3
+
+```
+Gnupru 2025.05 - GCC 15.1
+	text	   data	    bss	    dec	    hex	filename
+   7484	    496	    544	   8524	   214c	gen_gcc/pru0-shepherd-EMU-fw.elf
+   4736	      0	    616	   5352	   14e8	gen_gcc/pru0-shepherd-HRV-fw.elf
+   2396	      0	    552	   2948	    b84	gen_gcc/pru1-shepherd-fw.elf
+   4164	    342	    544	   5050	   13ba	gen_gcc/pru0-programmer-SWD-fw.elf
+   5448	    345	    544	   6337	   18c1	gen_gcc/pru0-programmer-SBW-fw.elf
+Gnupru 2026.05 - GCC 16.1
+   7540	    496	    544	   8580	   2184	gen_gcc/pru0-shepherd-EMU-fw.elf
+   4648	      0	    616	   5264	   1490	gen_gcc/pru0-shepherd-HRV-fw.elf
+   2352	      0	    552	   2904	    b58	gen_gcc/pru1-shepherd-fw.elf
+   4156	    342	    544	   5042	   13b2	gen_gcc/pru0-programmer-SWD-fw.elf
+   5396	    345	    544	   6285	   188d	gen_gcc/pru0-programmer-SBW-fw.elf
+CGT v2.3.3
+   7784     300     524    8608    21a0 gen/pru0-shepherd-EMU.out
+   5056     200     536    5792    16a0 gen/pru0-shepherd-HRV.out
+   2004      58     512    2574     a0e gen/pru1-shepherd.out
+   5768     102     804    6674    1a12 gen/pru0-programmer-SWD.out
+   7944     112     796    8852    2294 gen/pru0-programmer-SBW.out
+```
+
+
+## 2025
+
+- GCC 15.1 action: https://github.com/nes-lab/shepherd/actions/runs/15343379026/job/43174242856
+- GCC 14.1 action: https://github.com/nes-lab/shepherd/actions/runs/15308861373/job/43068333598
+- GCC 13.1 action: https://github.com/nes-lab/shepherd/actions/runs/15343636460/job/43175016523
+- CGT v2.3.3
+
+```
+elf/byte   text	   data	    bss	    dec	    hex	filename
+
+88164    8112	    420	    544	   9076	   2374	pru0-shepherd-EMU-fw gcc-13.1
+90048    8140	    420	    544	   9104	   2390	pru0-shepherd-EMU-fw gcc-14.1
+85152    7744	    420	    544	   8708	   2204	pru0-shepherd-EMU-fw gcc-15.1
+84152    7600       332     544    8476    211c pru0-shepherd-EMU-fw cgt-2.3.3
+
+70496    5172	      0	    596	   5768	   1688	pru0-shepherd-HRV-fw.elf gcc-13.1
+70428    5172	      0	    596	   5768	   1688	pru0-shepherd-HRV-fw.elf gcc-14.1
+69324    4808	      0	    596	   5404	   151c	pru0-shepherd-HRV-fw.elf gcc-15.1
+76300    5168       220     544    5932    172c pru0-shepherd-HRV-fw.elf cgt-2.3.3
+
+34976    840	      0	    548	   1388	    56c	pru1-shepherd-fw gcc-13.1
+34956	 840	      0	    548	   1388	    56c pru1-shepherd-fw gcc-14.1
+42760    2364	      0	    552	   2916	    b64	pru1-shepherd-fw gcc-15.1
+62804    1944        58     512    2514     9d2 pru1-shepherd-fw cgt-2.3.3
+
+66336    4308	    342	    544	   5194	   144a	pru0-programmer-SWD-fw gcc-13.1
+66188    4256	    342	    544	   5142	   1416	pru0-programmer-SWD-fw gcc-14.1
+65768    4164	    342	    544	   5050	   13ba	pru0-programmer-SWD-fw gcc-15.1
+79084    5756       102     804    6662    1a06 pru0-programmer-SWD-fw cgt-2.3.3
+
+73456    5628	    345	    544	   6517	   1975	pru0-programmer-SBW-fw gcc-13.1
+73380    5552	    345	    544	   6441	   1929	pru0-programmer-SBW-fw gcc-14.1
+72504    5448	    345	    544	   6337	   18c1	pru0-programmer-SBW-fw gcc-15.1
+83356    7932     	112     796    8840    2288 pru0-programmer-SBW-fw cgt-2.3.3
+```

--- a/software/shepherd-calibration/pyproject.toml
+++ b/software/shepherd-calibration/pyproject.toml
@@ -6,7 +6,7 @@ maintainers = [{email = "ingmar.splitt@tu-dresden.de"}]
 description = "Synchronized Energy Harvesting Emulator and Recorder CLI"
 keywords = ["testbed", "beaglebone", "pru", "batteryless", "energyharvesting", "solar"]
 
-version = "2026.04.2"
+version = "2026.05.1"
 
 license = "MIT"
 

--- a/software/shepherd-herd/pyproject.toml
+++ b/software/shepherd-herd/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
     {name = "Ingmar Splitt", email = "ingmar.splitt@tu-dresden.de"},
 ]
 
-version = "2026.04.2"
+version = "2026.05.1"
 
 license = "MIT"
 
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "shepherd-core[elf,inventory]>=2026.04.2",  # limit due to newest features
+    "shepherd-core[elf,inventory]>=2026.05.1",  # limit due to newest features
     "click",
     "numpy",
     "fabric",


### PR DESCRIPTION
Sheep

- improve handling of kernel module - this prevents an endless reload-loop
- prevent early exit if power-tracing is disabled (10 s missing)
- ~~transform pru_util into a monitor-thread to prevent overfilling buffer during waiting~~
  - bad idea as a non-atomic monitor-thread corrupts shared-memory-access
  - better: add pre-experiment-loop that collects pru-util data
- add pre-experiment loop that collects pru-util data (avoids warning to user)
- sheep - read back and verify written settings in pru-memory (now default for emu & hrv)
- verify that settings where actually applied in PRU before starting a measurement (wasn't fully done for hrv)
- virtual harvester - ivsurface recorder - add fixed-length and automatic cutout-mode
  - the config-model got new parameters and the firmware is respecting them
  - documentation can be found here: https://github.com/nes-lab/shepherd/blob/main/docs/user/virtual_harvester.md#ivsurface---transition-cutout

KModule

- allow reading and resetting pru-applied-settings-flag
- bugfix - forced PRU-reset could be discarded before

Watchdog

- add network-checker that pings 5 internet-hosts and reboots after all failed
  - feature is turned off per default as it can misbehave in harvesting-scenarios without internet access
- config is located @ `/etc/shepherd/watchdog.yaml`

Ansible

- install / build rYAML separately from install sheep

Github

- compile PRU-firmware with GCC 16.1, gnupru 2026.05