### PR TITLE
reliability-booster for pru-programmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # History of Changes
 
-## 2026.05.1 - unreleased
+## 2026.05.2 - unreleased
+
+PRU-Programmer got the same reliability-booster as emulation & harvester
+
+- PRU logs that settings were applied
+- python checks if config was written correctly to PRU-memory
+- python checks if PRU applied settings
+- note that the programmer got more reliable with the last release as well -> forced pru-resets are not occasionally discarded
+
+## 2026.05.1
 
 Sheep
 

--- a/software/firmware/pru0-programmer/programmer.c
+++ b/software/firmware/pru0-programmer/programmer.c
@@ -79,9 +79,10 @@ void programmer(volatile struct ProgrammerCtrl *const pctrl, volatile const uint
     }
 
     ihex_reader_init((char *) fw_data);
+    SHARED_MEM.pru_applied_settings = true;
 
     /* State specifies number of bytes written to target */
-    pctrl->state = 0;
+    pctrl->state                    = 0;
 
     int rc;
     /* Iterate content of hex file entry by entry */

--- a/software/python-package/shepherd_sheep/shepherd_run_functions.py
+++ b/software/python-package/shepherd_sheep/shepherd_run_functions.py
@@ -168,7 +168,7 @@ def run_programmer(cfg: ProgrammingTask, rate_factor: float = 1.0) -> bool:
                 if cfg.simulate:
                     target = "dummy"
                 if cfg.mcu_port == 1:
-                    sysfs_interface.write_programmer_ctrl(
+                    sysfs_interface.send_programmer_ctrl(
                         target,
                         data_rate,
                         5,
@@ -176,13 +176,14 @@ def run_programmer(cfg: ProgrammingTask, rate_factor: float = 1.0) -> bool:
                         10,
                     )
                 else:
-                    sysfs_interface.write_programmer_ctrl(
+                    sysfs_interface.send_programmer_ctrl(
                         target,
                         data_rate,
                         8,
                         9,
                         11,
                     )
+                sysfs_interface.reset_pru_applied_settings()
                 log.info("Programmer initialized, will start now (data-rate = %d bit/s)", data_rate)
                 sysfs_interface.start_programmer()
             except OSError as xpt:
@@ -192,9 +193,12 @@ def run_programmer(cfg: ProgrammingTask, rate_factor: float = 1.0) -> bool:
                 log.exception("ValueError: %s", str(xpt))
                 failed = True
 
+        time.sleep(1)  # give PRU some time to start (relax race-condition for settings-check)
         state = None
         counter = 0
         while state != "idle" and not failed:
+            if not sysfs_interface.check_pru_applied_settings():
+                log.error("PRU has NOT yet applied the settings!")
             log.info(
                 "Programming in progress,\tpgm_state = %s, shp_state = %s",
                 state,

--- a/software/python-package/shepherd_sheep/sysfs_interface.py
+++ b/software/python-package/shepherd_sheep/sysfs_interface.py
@@ -616,6 +616,38 @@ def read_programmer_ctrl() -> list:
     return parameters
 
 
+def send_programmer_ctrl(
+    target: str,
+    datarate: int,
+    pin_tck: int,
+    pin_tdio: int,
+    pin_dir_tdio: int,
+    pin_tdo: int = 0,
+    pin_tms: int = 0,
+    pin_dir_tms: int = 0,
+    *,
+    verify: bool = True,
+) -> bool:
+    write_programmer_ctrl(
+        target, datarate, pin_tck, pin_tdio, pin_dir_tdio, pin_tdo, pin_tms, pin_dir_tms
+    )
+    if verify:
+        identical = True
+        values_wanted = locals()
+        values_present = read_programmer_ctrl()
+        for num, attribute in enumerate(prog_attribs):
+            identical &= (
+                str(values_wanted[attribute]).lower().strip()
+                == str(values_present[num]).lower().strip()
+            )
+        if not identical:
+            log.warning("Programmer-settings - expected vs present in pru-memory:")
+            log.warning("\t%s", values_wanted)
+            log.warning("\t%s", values_present)
+        return identical
+    return True
+
+
 def write_programmer_datasize(value: int) -> None:
     with Path("/sys/shepherd/programmer/datasize").open("w", encoding="utf-8") as file:
         file.write(str(value))


### PR DESCRIPTION
PRU-Programmer got the same reliability-booster as emulation & harvester

- PRU logs that settings were applied
- python checks if config was written correctly to PRU-memory
- python checks if PRU applied settings
- note that the programmer got more reliable with the last release as well -> forced pru-resets are not occasionally discarded