### PR TITLE
Make filesystem more robust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.17
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # History of Changes
 
-## 2026.06.1 - unreleased
+## 2026.06.2 - unreleased
+
+Make the root filesystem less prone to errors
+
+- added playbook `dev_harden_rootfs.yml`
+- strategy 1 - move temporary data from FS to RAM
+- strategy 2 - make mounting of root-filesystem more robust
+- strategy 3 - check filesystem on every boot (NOT active)
+  - this caused the kMod to NOT start up, because PRU0 could not load firmware, because allocation of buffers in DRAM failed
+  - 3 possible fixes were tried (https://github.com/nes-lab/shepherd/issues/162), all failed
+  - migration to a newer kernel is recommended
+
+Other Changes
+
+- kModule informs about buffer-specs in DRAM (address & size)
+
+## 2026.06.1
 
 PRU-Programmer got the same reliability-booster as emulation & harvester
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # History of Changes
 
-## 2026.05.2 - unreleased
+## 2026.06.2 - unreleased
+
+## 2026.06.1
 
 PRU-Programmer got the same reliability-booster as emulation & harvester
 
@@ -8,6 +10,20 @@ PRU-Programmer got the same reliability-booster as emulation & harvester
 - python checks if config was written correctly to PRU-memory
 - python checks if PRU applied settings
 - note that the programmer got more reliable with the last release as well -> forced pru-resets are not occasionally discarded
+
+Sheep
+
+- cleaner exit on already misbehaving sheep-routines
+- ID-patching now informs if it skips due to wrong file-format
+- shorten programmer error-count before failing -> gives more time for retries
+
+KMod - fixed leakage of Pru-handles during loading and unloading of module
+
+- when PRUs were not fully ready during boot, references were lost in several places
+- during removal, the references were not returned at all
+- code was made much safer by handling all possible code-paths (proper cleanup)
+- test with `sudo lsmod | grep pru_rproc` before and after `sudo python3 python-package/tests_manual/testbench_kernelmodule.py`
+  - reference count of sub-modules is correct and does not increase during usage
 
 ## 2026.05.1
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,7 @@ host_key_checking = False
 forks=50
 # ⤷ parallel instances (should be >host-size)
 inventory = inventory
+# inventory = /etc/shepherd/herd.yaml
 # TODO: try list to also hint at /etc/shepherd/herd.yaml or ~/herd.yaml
 
 [ssh_connection]

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -59,4 +59,3 @@
         connect_timeout: 20
         reboot_timeout: 200
         post_reboot_delay: 30
-      when: false

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -1,0 +1,72 @@
+---
+- name: Strategies to prevent filesystem corruption
+  hosts: all
+  become: true
+
+  tasks:
+
+    # STRATEGY 1 - move temporary data to RAM
+    - name: Convert /tmp to temporary file system
+      ansible.builtin.lineinfile:
+        dest: /etc/fstab
+        regex: '^tmpfs.+\/tmp.*$'
+        line: 'tmpfs   /tmp        tmpfs   defaults,noatime,nosuid,size=100M   0  0'
+        state: present
+      become: true
+    - name: Convert /var/log  to temporary file system
+      ansible.builtin.lineinfile:
+        dest: /etc/fstab
+        regex: '^tmpfs.+\/var\/log.*$'
+        line: 'tmpfs   /var/log    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
+        state: present
+      become: true
+    - name: Convert /var/run  to temporary file system
+      ansible.builtin.lineinfile:
+        dest: /etc/fstab
+        regex: '^tmpfs.+\/var\/run.*$'
+        line: 'tmpfs   /var/run    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
+        state: present
+      become: true
+
+    # STRATEGY 2 - make root-filesystem more robust
+    # - noatime & nodiratime -> prevent logging access of files and directories
+    # - data=ordered -> write data first, then metadata (cost a bit of performance,
+    #                   but prevents corrupted orphan linked lists
+    # - errors=continue -> continue booting
+    #                      default is: errors=remount-ro
+    - name: Detect eMMC-usage
+      ansible.builtin.shell:
+        cmd: "set -o pipefail && df -h | grep mmcblk1p1"
+      register: booted_eMMC
+      changed_when: false
+    - name: Make eMMC-FS safer
+      ansible.builtin.lineinfile:
+        dest: /etc/fstab
+        regex: '^\/dev\/mmcblk.*$'
+        line: '/dev/mmcblk1p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
+        state: present
+      when: booted_eMMC.rc == 0
+      become: true
+
+    - name: Detect microSD-usage
+      ansible.builtin.shell:
+        cmd: "set -o pipefail && df -h | grep mmcblk0p1"
+      register: booted_microSD
+      changed_when: false
+    - name: Make microSD-FS safer
+      ansible.builtin.lineinfile:
+        dest: /etc/fstab
+        regex: '^\/dev\/mmcblk.*$'
+        line: '/dev/mmcblk0p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
+        state: present
+      when: booted_microSD.rc == 0
+      become: true
+
+      # STRATEGY 3 - check filesystem on every boot
+    - name: Check root-filesystem on every boot
+      ansible.builtin.lineinfile:
+        dest: "/boot/uEnv.txt"
+        regexp: "#?cmdline=coherent.*. quiet$"
+        line: "cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 rootdelay=10 fsck.mode=force fsck.repair=yes quiet"
+        state: present
+      become: true

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -17,7 +17,7 @@
         - { dir: '/var/log', size: 64 }
         - { dir: '/var/run', size: 64 }
 
-    # STRATEGY 2 - make root-filesystem more robust
+    # STRATEGY 2 - make mounting of root-filesystem more robust
     # - noatime & nodiratime -> prevent logging access of files and directories
     # - data=ordered -> write data first, then metadata (cost a bit of performance,
     #                   but prevents corrupted orphan linked lists

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -57,4 +57,3 @@
         connect_timeout: 20
         reboot_timeout: 200
         post_reboot_delay: 30
-      when: false

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -5,7 +5,7 @@
 
   tasks:
 
-    # STRATEGY 1 - move temporary data to RAM
+    # STRATEGY 1 - move temporary data from FS to RAM
     - name: Convert /tmp to temporary file system
       ansible.builtin.lineinfile:
         dest: /etc/fstab
@@ -31,38 +31,28 @@
     #                   but prevents corrupted orphan linked lists
     # - errors=continue -> continue booting
     #                      default is: errors=remount-ro
-    - name: Detect eMMC-usage
+    - name: Detect root partition (eMMC vs SD-Card)
       ansible.builtin.shell:
-        cmd: "set -o pipefail && df -h | grep mmcblk1p1"
-      register: booted_emmc
+        cmd: "set -o pipefail && df -h | grep mmcblk | cut -d ' ' --fields=1"
+      register: booted_part
       failed_when: false
-    - name: Make eMMC-FS safer
+      changed_when: false
+    - name: Make mounting of root partition safer
       ansible.builtin.lineinfile:
         dest: /etc/fstab
         regex: '^\/dev\/mmcblk.*$'
-        line: '/dev/mmcblk1p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
+        line: '{{ booted_part.stdout }}  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
         state: present
-      when: booted_emmc is not failed
 
-    - name: Detect microSD-usage
-      ansible.builtin.shell:
-        cmd: "set -o pipefail && df -h | grep mmcblk0p1"
-      register: booted_microsd
-      failed_when: false
-    - name: Make microSD-FS safer
-      ansible.builtin.lineinfile:
-        dest: /etc/fstab
-        regex: '^\/dev\/mmcblk.*$'
-        line: '/dev/mmcblk0p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
-        state: present
-      when: booted_microsd is not failed
-
-      # STRATEGY 3 - check filesystem on every boot
+      # STRATEGY 3 - check filesystem on every boot (NOT active)
     - name: Check root-filesystem on every boot
       ansible.builtin.lineinfile:
         dest: "/boot/uEnv.txt"
         regexp: "#?cmdline=coherent.*. quiet$"
-        line: "cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 rootdelay=10 fsck.mode=force fsck.repair=yes quiet"
+        line: "cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 fsck.mode=yes fsck.repair=yes quiet"
+        # TODO: removed 'fsck.mode=force' for now, as this prevents PRU0 from carving out RAM
+        #       tried 3 ways to circumvent this, all failed
+        #       https://github.com/nes-lab/shepherd/issues/162
         state: present
 
 # TODO: reboot

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -39,6 +39,7 @@
         cmd: "set -o pipefail && df -h | grep mmcblk1p1"
       register: booted_eMMC
       changed_when: false
+      failed_when: false
     - name: Make eMMC-FS safer
       ansible.builtin.lineinfile:
         dest: /etc/fstab
@@ -53,6 +54,7 @@
         cmd: "set -o pipefail && df -h | grep mmcblk0p1"
       register: booted_microSD
       changed_when: false
+      failed_when: false
     - name: Make microSD-FS safer
       ansible.builtin.lineinfile:
         dest: /etc/fstab

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -25,7 +25,9 @@
     #                      default is: errors=remount-ro
     - name: Detect root partition (eMMC vs SD-Card)
       ansible.builtin.shell:
-        cmd: "mount | grep ' / ' | cut -d ' ' --fields=1"
+        # cmd: "set -o pipefail && mount | grep ' / ' | cut -d' ' --fields=1"
+        # cmd: "mount | grep ' / ' | cut -d' ' --fields=1"
+        cmd: "df -h | grep mmcblk | cut -d' ' --fields=1"
         # note: "set -o pipefail &&" in front does not work here -> empty string
       register: booted_part
       failed_when: false
@@ -57,3 +59,4 @@
         connect_timeout: 20
         reboot_timeout: 200
         post_reboot_delay: 30
+      when: false

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -12,21 +12,18 @@
         regex: '^tmpfs.+\/tmp.*$'
         line: 'tmpfs   /tmp        tmpfs   defaults,noatime,nosuid,size=100M   0  0'
         state: present
-      become: true
     - name: Convert /var/log  to temporary file system
       ansible.builtin.lineinfile:
         dest: /etc/fstab
         regex: '^tmpfs.+\/var\/log.*$'
         line: 'tmpfs   /var/log    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
         state: present
-      become: true
     - name: Convert /var/run  to temporary file system
       ansible.builtin.lineinfile:
         dest: /etc/fstab
         regex: '^tmpfs.+\/var\/run.*$'
         line: 'tmpfs   /var/run    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
         state: present
-      become: true
 
     # STRATEGY 2 - make root-filesystem more robust
     # - noatime & nodiratime -> prevent logging access of files and directories
@@ -37,8 +34,7 @@
     - name: Detect eMMC-usage
       ansible.builtin.shell:
         cmd: "set -o pipefail && df -h | grep mmcblk1p1"
-      register: booted_eMMC
-      changed_when: false
+      register: booted_emmc
       failed_when: false
     - name: Make eMMC-FS safer
       ansible.builtin.lineinfile:
@@ -46,14 +42,12 @@
         regex: '^\/dev\/mmcblk.*$'
         line: '/dev/mmcblk1p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
         state: present
-      when: booted_eMMC.rc == 0
-      become: true
+      when: booted_emmc is not failed
 
     - name: Detect microSD-usage
       ansible.builtin.shell:
         cmd: "set -o pipefail && df -h | grep mmcblk0p1"
-      register: booted_microSD
-      changed_when: false
+      register: booted_microsd
       failed_when: false
     - name: Make microSD-FS safer
       ansible.builtin.lineinfile:
@@ -61,8 +55,7 @@
         regex: '^\/dev\/mmcblk.*$'
         line: '/dev/mmcblk0p1  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
         state: present
-      when: booted_microSD.rc == 0
-      become: true
+      when: booted_microsd is not failed
 
       # STRATEGY 3 - check filesystem on every boot
     - name: Check root-filesystem on every boot
@@ -71,4 +64,5 @@
         regexp: "#?cmdline=coherent.*. quiet$"
         line: "cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 rootdelay=10 fsck.mode=force fsck.repair=yes quiet"
         state: present
-      become: true
+
+# TODO: reboot

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Strategies to prevent filesystem corruption
-  hosts: all
+  hosts: sheep
   become: true
 
   tasks:

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -9,13 +9,13 @@
     - name: Move temporary data from filesystem to RAM
       ansible.builtin.lineinfile:
         dest: /etc/fstab
-        regex: "^tmpfs.+{{ item | replace('/', '\/') }}.*$"
-        line: 'tmpfs   {{ item }}    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
+        regex: "^tmpfs.+{{ item.dir | replace('/', '\/') }}.*$"
+        line: 'tmpfs   {{ item.dir }}    tmpfs   defaults,noatime,nosuid,size={{ item.size }}M    0  0'
         state: present
       loop:
-        - '/tmp'
-        - '/var/log'
-        - '/var/run'
+        - { dir: '/tmp', size: 100 }
+        - { dir: '/var/log', size: 64 }
+        - { dir: '/var/run', size: 64 }
 
     # STRATEGY 2 - make root-filesystem more robust
     # - noatime & nodiratime -> prevent logging access of files and directories
@@ -25,16 +25,20 @@
     #                      default is: errors=remount-ro
     - name: Detect root partition (eMMC vs SD-Card)
       ansible.builtin.shell:
-        cmd: "df -h | grep mmcblk | cut -d ' ' --fields=1"
+        cmd: "set -o pipefail && mount | grep ' / ' | cut -d ' ' --fields=1"
       register: booted_part
       failed_when: false
       changed_when: false
+    - name: Root partition is
+      ansible.builtin.debug:
+        msg: "{{ booted_part.stdout }}"
     - name: Make mounting of root partition safer
       ansible.builtin.lineinfile:
         dest: /etc/fstab
-        regex: '^\/dev\/mmcblk.*$'
+        regex: '^.* \/ .*$'
         line: '{{ booted_part.stdout }}  /  ext4  noatime,nodiratime,data=ordered,errors=continue  0  1'
         state: present
+        insertafter: EOF
 
       # STRATEGY 3 - check filesystem on every boot (NOT active)
     - name: Check root-filesystem on every boot
@@ -47,4 +51,9 @@
         #       https://github.com/nes-lab/shepherd/issues/162
         state: present
 
-# TODO: reboot
+    - name: Restart device
+      ansible.builtin.reboot:
+        connect_timeout: 20
+        reboot_timeout: 200
+        post_reboot_delay: 30
+      when: false

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -6,24 +6,16 @@
   tasks:
 
     # STRATEGY 1 - move temporary data from FS to RAM
-    - name: Convert /tmp to temporary file system
+    - name: Move temporary data from filesystem to RAM
       ansible.builtin.lineinfile:
         dest: /etc/fstab
-        regex: '^tmpfs.+\/tmp.*$'
-        line: 'tmpfs   /tmp        tmpfs   defaults,noatime,nosuid,size=100M   0  0'
+        regex: "^tmpfs.+{{ item | replace('/', '\/') }}.*$"
+        line: 'tmpfs   {{ item }}    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
         state: present
-    - name: Convert /var/log  to temporary file system
-      ansible.builtin.lineinfile:
-        dest: /etc/fstab
-        regex: '^tmpfs.+\/var\/log.*$'
-        line: 'tmpfs   /var/log    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
-        state: present
-    - name: Convert /var/run  to temporary file system
-      ansible.builtin.lineinfile:
-        dest: /etc/fstab
-        regex: '^tmpfs.+\/var\/run.*$'
-        line: 'tmpfs   /var/run    tmpfs   defaults,noatime,nosuid,size=64M    0  0'
-        state: present
+      loop:
+        - '/tmp'
+        - '/var/log'
+        - '/var/run'
 
     # STRATEGY 2 - make root-filesystem more robust
     # - noatime & nodiratime -> prevent logging access of files and directories
@@ -33,7 +25,7 @@
     #                      default is: errors=remount-ro
     - name: Detect root partition (eMMC vs SD-Card)
       ansible.builtin.shell:
-        cmd: "set -o pipefail && df -h | grep mmcblk | cut -d ' ' --fields=1"
+        cmd: "df -h | grep mmcblk | cut -d ' ' --fields=1"
       register: booted_part
       failed_when: false
       changed_when: false

--- a/deploy/dev_harden_rootfs.yml
+++ b/deploy/dev_harden_rootfs.yml
@@ -25,7 +25,8 @@
     #                      default is: errors=remount-ro
     - name: Detect root partition (eMMC vs SD-Card)
       ansible.builtin.shell:
-        cmd: "set -o pipefail && mount | grep ' / ' | cut -d ' ' --fields=1"
+        cmd: "mount | grep ' / ' | cut -d ' ' --fields=1"
+        # note: "set -o pipefail &&" in front does not work here -> empty string
       register: booted_part
       failed_when: false
       changed_when: false

--- a/software/firmware/device-tree/BB-SHPRD-24A0.dts
+++ b/software/firmware/device-tree/BB-SHPRD-24A0.dts
@@ -195,6 +195,7 @@
             status = "okay";
             pinctrl-names = "default";
             pinctrl-0 = <&bb_shprd_pins>;
+            //memory-region = <&pru_dma_pool>;
             shepherd{
                compatible = "nes,shepherd";
                prusses = <&pruss>;
@@ -202,4 +203,26 @@
        };
    };
 
+/*
+    // also needed is "memory-region =" in fragment@2
+    // TODO: PRU carves out its own memory, so it won't use this (yet)
+    fragment@3 {
+        target-path = "/";
+        __overlay__ {
+            reserved-memory {
+                #address-cells = <0x01>;
+                #size-cells = <0x01>;
+                ranges;
+
+                pru_dma_pool: pru-dma-pool@9C200000 {
+                    compatible = "shared-dma-pool";
+                    //reg = <0x9C200000 0x3000000>; // 50 MB
+                    reg = <0x9C000000 0x02dc6524>; // 48 MB
+                    no-map;
+                    status = "okay";
+                };
+            };
+        };
+    };
+*/
 };

--- a/software/kernel-module/src/ocmc_cache.c
+++ b/software/kernel-module/src/ocmc_cache.c
@@ -66,10 +66,17 @@ void ocmc_cache_init(void)
 
     ocmc_cache_reset();
 
-    printk(KERN_INFO "shprd.cache: OCMC initialized @ 0x%X, size = %d bytes",
+    printk(KERN_INFO "shprd.cache: OCMC initialized  @ 0x%X, size = %d bytes",
            (uint32_t) OCMC_BASE_ADDR, OCMC_SIZE);
-    printk(KERN_INFO "shprd.cache:     input-buffer @ 0x%X, size = %d bytes",
-           (uint32_t) shared_mem->buffer_iv_inp_ptr, sizeof(struct IVTraceInp));
+    printk(KERN_INFO "shprd.cache:     input-buffer  @ 0x%X, size = %d bytes",
+           (uint32_t) shared_mem->buffer_iv_inp_ptr, shared_mem->buffer_iv_inp_size);
+    // more info on current memory regions
+    printk(KERN_INFO "shprd.info:      output-buffer @ 0x%X, size = %d bytes",
+           (uint32_t) shared_mem->buffer_iv_out_ptr, shared_mem->buffer_iv_out_size);
+    printk(KERN_INFO "shprd.info:      gpio-buffer   @ 0x%X, size = %d bytes",
+           (uint32_t) shared_mem->buffer_gpio_ptr, shared_mem->buffer_gpio_size);
+    printk(KERN_INFO "shprd.info:      util-buffer   @ 0x%X, size = %d bytes",
+           (uint32_t) shared_mem->buffer_util_ptr, shared_mem->buffer_util_size);
 
     /* timer for updates */
     hrtimer_init(&update_timer, CLOCK_REALTIME, HRTIMER_MODE_ABS);


### PR DESCRIPTION
Make the root filesystem less prone to errors

- added playbook `dev_harden_rootfs.yml`
- strategy 1 - move temporary data from FS to RAM
- strategy 2 - make mounting of root-filesystem more robust
- strategy 3 - check filesystem on every boot (NOT active)
  - this caused the kMod to NOT start up, because PRU0 could not load firmware, because allocation of buffers in DRAM failed
  - 3 possible fixes were tried (https://github.com/nes-lab/shepherd/issues/162), all failed
  - migration to a newer kernel is recommended

Other Changes

- kModule informs about buffer-specs in DRAM (address & size)