### PR TITLE
Dev

### DIFF
--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -1,11 +1,29 @@
 ---
 
+- name: Update Time
+  hosts: sheep
+  become: true
+  strategy: free  # noqa: run-once[play]
+  # ⤷ ansible won't wait for every host to continue next task
+
+  tasks:
+
+    - name: Get time and date from ansible controller
+      ansible.builtin.command: 'date -u +"%Y-%m-%dT%H:%M:%SZ"'
+      delegate_to: localhost
+      changed_when: false
+      register: local_time
+      become: false
+    - name: Set correct time
+      ansible.builtin.command: "date -s {{ local_time.stdout }}"
+      changed_when: true
+
 - name: PTP-Host -> update service-config
   hosts: sheep
   become: true
   strategy: free # noqa: run-once[play]
   roles:
-    - ptp_client
+    - ptp_host
 
 - name: PTP - make it less susceptible to high CPU util
   hosts: sheep
@@ -43,6 +61,7 @@
         regexp: "kernel.sched_rt_runtime_us.*$"
         line: "kernel.sched_rt_runtime_us = -1"
         state: present
+        create: true
 
     - name: allow more RT-threads (immediate)
       ansible.builtin.shell:

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -1,0 +1,32 @@
+---
+- name: PTP - make it less susceptible to high CPU util
+  hosts: sheep
+  become: true
+
+  tasks:
+
+    - name: Configure PTP for higher timeouts
+      ansible.builtin.lineinfile:
+        dest: "/etc/linuxptp/ptp4l.conf"
+        regexp: "{{ item.regex }}"
+        line: "{{ item.replacement }}"
+        state: present
+      loop:
+        - {
+          regex: "delay_response_timeout.*$",
+          replacement: "delay_response_timeout  0",
+        }
+        - {
+          regex: "tx_timestamp_timeout.*$",
+          replacement: "tx_timestamp_timeout  100",
+        }
+
+    - name: Determine CPU-Governor
+      ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'
+      register: cpu_governor
+      changed_when: false
+
+    - name: Active CPU-Governor (should be performance)
+      ansible.builtin.debug:
+        msg:
+          - "governor = {{ cpu_governor..stdout.strip() }} "

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -44,7 +44,7 @@
         #  # does not exist in current ptp-version
         #}
         - {
-          regex: "^.tx_timestamp_timeout.*$",
+          regex: "^.?tx_timestamp_timeout.*$",
           replacement: "tx_timestamp_timeout  1", # 1 is default
           # NOTE that relaxing timeout to 100 did more harm? no
         }
@@ -52,7 +52,7 @@
     - name: Remove faulty parameter
       ansible.builtin.lineinfile:
         dest: "/etc/linuxptp/ptp4l.conf"
-        regexp: "^.delay_response_timeout.*$"
+        regexp: "^.?delay_response_timeout.*$"
         state: absent
 
     - name: bump priority of PTP0
@@ -65,7 +65,7 @@
     - name: allow more RT-threads
       ansible.builtin.lineinfile:
         dest: "/etc/sysctl.d/99-rt.conf"
-        regexp: "kernel.sched_rt_runtime_us.*$"
+        regexp: "^.?kernel.sched_rt_runtime_us.*$"
         line: "kernel.sched_rt_runtime_us = -1"
         state: present
         create: true

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -18,8 +18,12 @@
         }
         - {
           regex: "tx_timestamp_timeout.*$",
-          replacement: "tx_timestamp_timeout  100",
+          replacement: "tx_timestamp_timeout  1", # 1 is default
+          # NOTE that relaxing timeout to 100 did more harm
         }
+
+    - name: bump priority of PTP
+      ansible.builtin.command: 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -f --pid 75 {}'
 
     - name: Determine CPU-Governor
       ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -5,6 +5,12 @@
 
   tasks:
 
+    - name: Role - PTP-Host
+      become: true
+      strategy: free # noqa: run-once[play]
+      roles:
+        - ptp_host
+
     - name: Configure PTP for higher timeouts
       ansible.builtin.lineinfile:
         dest: "/etc/linuxptp/ptp4l.conf"

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -22,9 +22,27 @@
           # NOTE that relaxing timeout to 100 did more harm
         }
 
-    - name: bump priority of PTP
+    - name: bump priority of PTP0
       ansible.builtin.shell:
-        cmd: 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -f --pid 75 {}'
+        cmd: 'pgrep -f "ptp[0-3]+" | xargs -I {} sudo chrt -f --pid 60 {}'
+        # check with 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -p {}'
+        # check with 'pgrep -f "ptp[0-9]+" -l'
+        # TODO: make permanent
+
+    - name: allow more RT-threads
+      ansible.builtin.lineinfile:
+        dest: "/etc/sysctl.d/99-rt.conf"
+        regexp: "kernel.sched_rt_runtime_us.*$"
+        line: "kernel.sched_rt_runtime_us = -1"
+        state: present
+
+    - name: allow more RT-threads (immediate)
+      ansible.builtin.shell:
+        cmd: sudo sysctl -w kernel.sched_rt_runtime_us=-1
+
+    - name: Resync
+      ansible.builtin.shell:
+        cmd: sudo shepherd-sheep resync
 
     - name: Determine CPU-Governor
       ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -1,15 +1,17 @@
 ---
+
+- name: PTP-Host -> update service-config
+  hosts: sheep
+  become: true
+  strategy: free # noqa: run-once[play]
+  roles:
+    - ptp_client
+
 - name: PTP - make it less susceptible to high CPU util
   hosts: sheep
   become: true
 
   tasks:
-
-    - name: Role - PTP-Host
-      become: true
-      strategy: free # noqa: run-once[play]
-      roles:
-        - ptp_host
 
     - name: Configure PTP for higher timeouts
       ansible.builtin.lineinfile:

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -38,15 +38,22 @@
         line: "{{ item.replacement }}"
         state: present
       loop:
-        - {
-          regex: "^.delay_response_timeout.*$",
-          replacement: "#delay_response_timeout  0",
-        }
+        #- {
+        #  regex: "^.delay_response_timeout.*$",
+        #  replacement: "#delay_response_timeout  0",
+        #  # does not exist in current ptp-version
+        #}
         - {
           regex: "^.tx_timestamp_timeout.*$",
           replacement: "tx_timestamp_timeout  1", # 1 is default
           # NOTE that relaxing timeout to 100 did more harm? no
         }
+
+    - name: Remove faulty parameter
+      ansible.builtin.lineinfile:
+        dest: "/etc/linuxptp/ptp4l.conf"
+        regexp: "^.delay_response_timeout.*$"
+        state: absent
 
     - name: bump priority of PTP0
       ansible.builtin.shell:

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -29,4 +29,4 @@
     - name: Active CPU-Governor (should be performance)
       ansible.builtin.debug:
         msg:
-          - "governor = {{ cpu_governor..stdout.strip() }} "
+          - "gov={{ cpu_governor.stdout.strip() }}"

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -39,13 +39,13 @@
         state: present
       loop:
         - {
-          regex: "delay_response_timeout.*$",
-          replacement: "delay_response_timeout  0",
+          regex: "^.delay_response_timeout.*$",
+          replacement: "#delay_response_timeout  0",
         }
         - {
-          regex: "tx_timestamp_timeout.*$",
+          regex: "^.tx_timestamp_timeout.*$",
           replacement: "tx_timestamp_timeout  1", # 1 is default
-          # NOTE that relaxing timeout to 100 did more harm
+          # NOTE that relaxing timeout to 100 did more harm? no
         }
 
     - name: bump priority of PTP0

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -23,7 +23,8 @@
         }
 
     - name: bump priority of PTP
-      ansible.builtin.command: 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -f --pid 75 {}'
+      ansible.builtin.shell:
+        cmd: 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -f --pid 75 {}'
 
     - name: Determine CPU-Governor
       ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'

--- a/deploy/dev_tune_ptp_clients.yml
+++ b/deploy/dev_tune_ptp_clients.yml
@@ -24,66 +24,14 @@
   strategy: free # noqa: run-once[play]
   roles:
     - ptp_host
+    # Tuning is now completely integrated here
 
-- name: PTP - make it less susceptible to high CPU util
+- name: Resync
   hosts: sheep
   become: true
 
   tasks:
 
-    - name: Configure PTP for higher timeouts
-      ansible.builtin.lineinfile:
-        dest: "/etc/linuxptp/ptp4l.conf"
-        regexp: "{{ item.regex }}"
-        line: "{{ item.replacement }}"
-        state: present
-      loop:
-        #- {
-        #  regex: "^.delay_response_timeout.*$",
-        #  replacement: "#delay_response_timeout  0",
-        #  # does not exist in current ptp-version
-        #}
-        - {
-          regex: "^.?tx_timestamp_timeout.*$",
-          replacement: "tx_timestamp_timeout  1", # 1 is default
-          # NOTE that relaxing timeout to 100 did more harm? no
-        }
-
-    - name: Remove faulty parameter
-      ansible.builtin.lineinfile:
-        dest: "/etc/linuxptp/ptp4l.conf"
-        regexp: "^.?delay_response_timeout.*$"
-        state: absent
-
-    - name: bump priority of PTP0
-      ansible.builtin.shell:
-        cmd: 'pgrep -f "ptp[0-3]+" | xargs -I {} sudo chrt -f --pid 60 {}'
-        # check with 'pgrep -f "ptp[0-9]+" | xargs -I {} sudo chrt -p {}'
-        # check with 'pgrep -f "ptp[0-9]+" -l'
-        # TODO: make permanent
-
-    - name: allow more RT-threads
-      ansible.builtin.lineinfile:
-        dest: "/etc/sysctl.d/99-rt.conf"
-        regexp: "^.?kernel.sched_rt_runtime_us.*$"
-        line: "kernel.sched_rt_runtime_us = -1"
-        state: present
-        create: true
-
-    - name: allow more RT-threads (immediate)
-      ansible.builtin.shell:
-        cmd: sudo sysctl -w kernel.sched_rt_runtime_us=-1
-
     - name: Resync
       ansible.builtin.shell:
         cmd: sudo shepherd-sheep resync
-
-    - name: Determine CPU-Governor
-      ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'
-      register: cpu_governor
-      changed_when: false
-
-    - name: Active CPU-Governor (should be performance)
-      ansible.builtin.debug:
-        msg:
-          - "gov={{ cpu_governor.stdout.strip() }}"

--- a/deploy/roles/ptp_host/files/phc2sys@.service
+++ b/deploy/roles/ptp_host/files/phc2sys@.service
@@ -29,10 +29,12 @@ StartLimitBurst=10
 # improve responsiveness with RT
 RestrictRealtime=false
 LimitRTPRIO=infinity
-CPUSchedulingPriority=90
-CPUSchedulingPolicy=rr
+CPUSchedulingPriority=65
+CPUSchedulingPolicy=fifo
 IOSchedulingClass=realtime
 IOSchedulingPriority=3
+# Optionally, allow memory locking if needed (less jitter through page-faults)
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/roles/ptp_host/files/ptp4l@.service
+++ b/deploy/roles/ptp_host/files/ptp4l@.service
@@ -16,7 +16,6 @@ ExecStart=/usr/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
 # slaveOnly     0/1     -> roles should be static
 # clock_servo   linreg/pi -> linreg should be superior
 
-
 RestartSec=5
 Restart=always
 StartLimitBurst=10
@@ -24,10 +23,12 @@ StartLimitBurst=10
 # improve responsiveness with RT
 RestrictRealtime=false
 LimitRTPRIO=infinity
-CPUSchedulingPriority=99
-CPUSchedulingPolicy=rr
+CPUSchedulingPriority=62
+CPUSchedulingPolicy=fifo
 IOSchedulingClass=realtime
 IOSchedulingPriority=3
+# Optionally, allow memory locking if needed (less jitter through page-faults)
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/roles/ptp_host/files/ptp4l@.service
+++ b/deploy/roles/ptp_host/files/ptp4l@.service
@@ -7,6 +7,7 @@ After=sys-subsystem-net-devices-%i.device
 [Service]
 Type=idle
 ExecStartPre=/usr/sbin/ntpdate -b -s -u pool.ntp.org
+ExecStartPre=-/usr/local/bin/set-ptp-kworker-prio.sh
 # ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/ptp4l.conf -i %I
 ExecStart=/usr/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
 # -2 -> IEEE 802.3 Network Transport, TODO: seems to produce "sheep03 ptp4l[4062]: [2837.436] port 1: bad message"

--- a/deploy/roles/ptp_host/files/set-ptp-kworker-prio.sh
+++ b/deploy/roles/ptp_host/files/set-ptp-kworker-prio.sh
@@ -7,3 +7,5 @@ sleep 0.2
 pgrep -f "ptp[0-3]" | while read pid; do
     sudo chrt -f --pid 60 "$pid"
 done
+# check with
+pgrep -f "ptp[0-9]+" | xargs -I {} chrt -p {}

--- a/deploy/roles/ptp_host/files/set-ptp-kworker-prio.sh
+++ b/deploy/roles/ptp_host/files/set-ptp-kworker-prio.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# copy to /usr/local/bin/set-ptp-kworker-prio.sh (with chmod +x)
+# Give the kernel PTP workqueue thread real-time priority
+# Wait a tiny moment to ensure the kthread is fully spawned
+sleep 0.2
+# The kworker command line typically contains "ptp0", "ptp1", etc.
+pgrep -f "ptp[0-3]" | while read pid; do
+    sudo chrt -f --pid 60 "$pid"
+done

--- a/deploy/roles/ptp_host/tasks/main.yml
+++ b/deploy/roles/ptp_host/tasks/main.yml
@@ -30,6 +30,18 @@
     - ptp
     - conf
 
+- name: Configure PTP for higher timeouts
+  ansible.builtin.lineinfile:
+    dest: "/etc/linuxptp/ptp4l.conf"
+    regexp: "{{ item.regex }}"
+    line: "{{ item.replacement }}"
+    state: present
+  loop:
+    - {
+      regex: "^.?tx_timestamp_timeout.*$",
+      replacement: "tx_timestamp_timeout  10", # 1 is default
+    }
+
 - name: Install ntpdate package
   ansible.builtin.apt:
     name: ntpdate
@@ -52,6 +64,27 @@
   # manual: sudo systemctl restart ptp4l@eth0
   # status: sudo journalctl -u ptp4l@eth0 -f
 
+- name: Deploy prio-script for kworker
+  ansible.builtin.copy:
+    src: "set-ptp-kworker-prio.sh"
+    dest: "/usr/local/bin/"
+    mode: '0755'
+  tags:
+    - ptp
+    - conf
+
+- name: allow more RT-threads
+  ansible.builtin.lineinfile:
+    dest: "/etc/sysctl.d/99-rt.conf"
+    regexp: "^.?kernel.sched_rt_runtime_us.*$"
+    line: "kernel.sched_rt_runtime_us = -1"
+    state: present
+    create: true
+
+- name: allow more RT-threads (immediate)
+  ansible.builtin.shell:
+    cmd: sudo sysctl -w kernel.sched_rt_runtime_us=-1
+
 - name: Install ethtool
   ansible.builtin.apt:
     name: ethtool
@@ -67,3 +100,13 @@
     - hardware-receive
   failed_when: false
   tags: ptp
+
+- name: Determine CPU-Governor
+  ansible.builtin.command: 'cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'
+  register: cpu_governor
+  changed_when: false
+
+- name: Check active CPU-Governor (should be 'performance')
+  ansible.builtin.debug:
+    msg:
+      - "gov={{ cpu_governor.stdout.strip() }}"

--- a/software/python-package/shepherd_sheep/h5_monitor_kernel.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_kernel.py
@@ -60,9 +60,9 @@ class KernelMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_ntp.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_ntp.py
@@ -61,9 +61,9 @@ class NTPMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_phc2sys.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_phc2sys.py
@@ -64,9 +64,9 @@ class PHC2SYSMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_phc2sys_log.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_phc2sys_log.py
@@ -64,9 +64,9 @@ class PHC2SYSLogMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_ptp.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_ptp.py
@@ -64,9 +64,9 @@ class PTPMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_ptp_log.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_ptp_log.py
@@ -64,9 +64,9 @@ class PTPLogMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_sheep.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_sheep.py
@@ -54,9 +54,9 @@ class SheepMonitor(Monitor):
         time.sleep(2 * self.poll_interval)  # give thread time to write last bits
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=5 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_sysutil.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_sysutil.py
@@ -84,9 +84,9 @@ class SysUtilMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/h5_monitor_uart.py
+++ b/software/python-package/shepherd_sheep/h5_monitor_uart.py
@@ -71,9 +71,9 @@ class UARTMonitor(Monitor):
     ) -> None:
         self.event.set()
         if self.thread is not None:
-            self.thread.join(timeout=2 * self.poll_interval)
+            self.thread.join(timeout=4 * self.poll_interval)
             if self.thread.is_alive():
-                log.error(
+                log.warning(
                     "[%s] thread failed to end itself - will delete that instance",
                     type(self).__name__,
                 )

--- a/software/python-package/shepherd_sheep/shared_mem_gpio_output.py
+++ b/software/python-package/shepherd_sheep/shared_mem_gpio_output.py
@@ -44,7 +44,7 @@ class SharedMemGPIOOutput:
     SIZE_SECTION: int = 4 + SIZE_SAMPLES + SIZE_CANARY
     # ⤷ consist of index, samples, canary
 
-    N_SAMPLES_PER_CHUNK: int = 100_000
+    N_SAMPLES_PER_CHUNK: int = 50_000  # ~ 500 kiB Chunk
     N_BUFFER_CHUNKS: int = N_SAMPLES // N_SAMPLES_PER_CHUNK
     # Overflow detection
     FILL_GAP: float = 1.0 / N_BUFFER_CHUNKS

--- a/software/python-package/shepherd_sheep/shared_mem_iv_output.py
+++ b/software/python-package/shepherd_sheep/shared_mem_iv_output.py
@@ -24,7 +24,7 @@ class SharedMemIVOutput:
     # ⤷ consist of index, samples, canary
 
     N_BUFFER_CHUNKS: int = 30
-    N_SAMPLES_PER_CHUNK: int = N_SAMPLES // N_BUFFER_CHUNKS
+    N_SAMPLES_PER_CHUNK: int = N_SAMPLES // N_BUFFER_CHUNKS  # 20k samples = 320 kiB
     DURATION_CHUNK_MS: int = N_SAMPLES_PER_CHUNK * commons.SAMPLE_INTERVAL_NS // 10**6
     # Overflow detection
     FILL_GAP: float = 1.0 / N_BUFFER_CHUNKS

--- a/software/python-package/shepherd_sheep/shepherd_emulator.py
+++ b/software/python-package/shepherd_sheep/shepherd_emulator.py
@@ -272,6 +272,7 @@ class ShepherdEmulator(ShepherdIO):
         # Main Loop
         ts_data_last = self.start_time
         buffer_segment_last = math.floor(duration_s / self.segment_period_s)
+        leave_main_loop = False
         for _, dsv, dsc in self.reader.read(
             start_n=self.buffer_segment_count,
             end_n=buffer_segment_last,
@@ -280,6 +281,8 @@ class ShepherdEmulator(ShepherdIO):
         ):
             # this loop fetches data and tries to fill it into the buffer
             # -> while there is no space it will do other tasks
+            if leave_main_loop:
+                break
 
             while not self.shared_mem.iv_inp.write(
                 data=IVTrace(voltage=dsv, current=dsc),
@@ -302,6 +305,7 @@ class ShepherdEmulator(ShepherdIO):
                     # TODO: this can't work - with the limiting tracers
                     if data_iv.timestamp() >= ts_end:
                         log.debug("Out of bound timestamp collected -> begin to exit now")
+                        leave_main_loop = True
                         break
                     ts_data_last = time.time()
                     if self.writer is not None:
@@ -320,9 +324,12 @@ class ShepherdEmulator(ShepherdIO):
                     # note that util is a criteria in this first loop
                     if ts_data_last - time.time() > 10:
                         log.error("Main sheep-routine ran dry for 10s, will STOP")
+                        leave_main_loop = True
                         break
+                    time.sleep(0.010)
+                else:
                     # rest of loop is non-blocking, so we better doze a while if nothing to do
-                    time.sleep(self.segment_period_s / 10)
+                    time.sleep(0.001)
                 if get_state() == "idle":
                     log.info("PRU-State changed to idle -> will STOP")
                     # TODO: timer in kMod stops PRU to idle -> this should be improved
@@ -330,6 +337,7 @@ class ShepherdEmulator(ShepherdIO):
                     #           (not intertwined like shp_pru_state)
                     #       b) running -> stopped /finish operations -> reset /able to start again
                     #       c) pru could stop itself (time-aware)
+                    leave_main_loop = True
                     break
 
         log.debug("FINISHED supplying input-data -> process remaining buffer")
@@ -362,6 +370,7 @@ class ShepherdEmulator(ShepherdIO):
                     log.debug("End of measurement reached -> will collect remaining data")
                     # refresh TS before the routine can run dry
                     # this prevents early exit when power-tracing is disabled
+                    force_subchunks = True
                     ts_data_last = time.time()
                     before_ts_end = False
                 self.handle_pru_messages(panic_on_restart=before_ts_end)
@@ -370,9 +379,10 @@ class ShepherdEmulator(ShepherdIO):
                     if not before_ts_end and (time.time() - ts_data_last > 3):
                         log.info("Data-collection ran dry for 3s -> begin to exit now")
                         break
-                    force_subchunks = True
+                    time.sleep(0.010)  # self.segment_period_s / 5
+                else:
                     # rest of loop is non-blocking, so we better doze a while if nothing to do
-                    time.sleep(self.segment_period_s / 5)
+                    time.sleep(0.001)
 
         except ShepherdPRUError as e:
             # We're done when the PRU has processed all emulation data buffers


### PR DESCRIPTION
- tune PTP to be less susceptible to high CPU util
  - increase prios and change scheduler of ptp-kworker, ptp, phc2sys
  - increase timeout for answer of kworker (PTP tends to jump)
- sheep
  - emu - force small 1 or 10 ms breaks in main loop (depending of workload)
  - emu - properly exit main-loop when faulty condition is detected
  - monitors - give more time to quit and just warn if that fails
  - gpio-recorder - decrease chunk-size from 1 MiB to 500 kiB (even out cpu-load)